### PR TITLE
docs: architecture and quality assessments (ADR 0024, audit index)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-None
+### Documentation
+
+- **Assessment HTML (`docs/audit/`, 2026-04-14):** [`2026-04-14-api-assessment.html`](docs/audit/2026-04-14-api-assessment.html) — completed with §8 actionable checklist, §9 document history, and TOC anchors for sections 7–9. [`2026-04-14-documentation-experience-assessment.html`](docs/audit/2026-04-14-documentation-experience-assessment.html) — restructured to the same backbone (scope/methodology, Tables 1–2 with shared score legend, scoring summary, gaps §5.1–5.3, mitigation phases, checklist, document history); fixed markup and removed redundant sections.
+- **[ADR 0024](docs/adr/0024-architecture-and-quality-assessment-documents.html)** (assessment / audit format): normative **published assessment backbone** (`#published-assessment-backbone`) aligned with those pages; Table 2 score scale, legend fragment injection, and `docs/assets/docs.css` bands; consolidated rollout/validation and references. See also [`docs/CHANGELOG.md`](docs/CHANGELOG.md) (2026-04-14).
 
 ## [1.1.1] — 2026-04-12
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Study App API
 
-FastAPI service for Study App domain workflows. Long-form documentation: [system analysis](docs/system-analysis.html), [engineering practices](docs/engineering-practices.html).
+FastAPI service for Study App domain workflows. Long-form documentation: [system analysis](docs/system-analysis.html), [engineering practices](docs/engineering-practices.html), [architecture & quality assessments](docs/audit/README.html).
 
 ## Contents
 
@@ -59,6 +59,7 @@ Useful: `make env-check`, `curl -s http://127.0.0.1:8000/live | jq`.
 | System analysis & error matrix | [system-analysis.html](docs/system-analysis.html) |
 | Developer guides (requirements, contracts, load testing, local dev, Docker/K8s) | [docs/developer/README.html](docs/developer/README.html) |
 | ADRs | [docs/adr/README.html](docs/adr/README.html) |
+| Architecture & quality assessments (audits) | [docs/audit/README.html](docs/audit/README.html) |
 | Runbooks | [docs/runbooks/README.html](docs/runbooks/README.html) |
 | OpenAPI (test) — Swagger UI for the baseline spec (browse only; no in-browser validation) | [docs/openapi-explorer.html](docs/openapi-explorer.html) |
 
@@ -153,6 +154,7 @@ study_app/
 │   ├── api/
 │   │   └── app/
 │   ├── assets/
+│   ├── audit/
 │   ├── backlog/
 │   ├── developer/  # Developer guides and onboarding
 │   ├── openapi/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,29 +4,34 @@ All notable changes to the **documentation tree** under `docs/` (and related doc
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## 2026-04-14
+
 
 ### Added
 
+- Shared **assessment score** styling: `docs/assets/docs.css` defines `--audit-score-*` colours, `.audit-score-table` cell classes (`score-excellent`, `score-good`, `score-needs-attention`; `score-neutral` remains an alias), and `.audit-score-legend` / swatch layout. Canonical legend markup: [`docs/assets/audit-score-legend-fragment.html`](assets/audit-score-legend-fragment.html), injected by [`docs/assets/docs-nav.js`](assets/docs-nav.js) into `<div class="audit-score-legend-include" data-legend-id="…">` placeholders (see [ADR 0024](adr/0024-architecture-and-quality-assessment-documents.html#assessment-score-scale)). `SKIP_HTML_INDENT_NORMALIZE` in [`scripts/format_docs_html.py`](../scripts/format_docs_html.py) includes the fragment file.
+
+- [ADR 0024](adr/0024-architecture-and-quality-assessment-documents.html): architecture and quality **assessment** documents — `docs/audit/` location, `YYYY-MM-DD-topic-assessment.html` naming, canonical HTML sections (lead metadata, Table 1 reference practices, Table 2 mapping/scores, narrative findings, mitigation, checklist, document history), goals, process (when to refresh, ownership, `docs/CHANGELOG.md`), relationship to ADRs/runbooks, alternatives, links to existing assessments, and a note on `SKIP_HTML_INDENT_NORMALIZE` in [`scripts/format_docs_html.py`](../scripts/format_docs_html.py).
+
+- [`scripts/format_docs_html.py`](../scripts/format_docs_html.py): optional skip list `SKIP_HTML_INDENT_NORMALIZE` so the line-based indenter does not corrupt long HTML pages with multiline list items (ADR 0024 registered).
+
 - [Developer guide 0010](developer/0010-make-commands-and-workflows.html): Make commands and workflows — PlantUML sources under [`docs/uml/make/`](uml/make/) (rendered PNGs via `make docs-fix`), composite pipeline and run/observability figures, tables of atomic targets by theme, if-then onboarding scenarios; linked from [docs index](index.html), [developer README](developer/README.html), [CONTRIBUTING](../CONTRIBUTING.md), [ADR 0008](adr/0008-make-command-taxonomy-and-workflow-entrypoints.html), [engineering-practices](engineering-practices.html), and [local development](developer/0007-local-development.html).
+
+### Changed
+
+- [ADR 0024](adr/0024-architecture-and-quality-assessment-documents.html): rewritten around a single **published assessment backbone** (ordered list: lead/TOC, scope/methodology, Table 1, Table 2 + injected legend, scoring summary, gaps 5.1–5.3, mitigation, optional beyond-baseline, checklist, document history); merged former implementation/validation into **Rollout and validation**; shorter alternatives; anchor `#published-assessment-backbone` replaces the old canonical-sections template list.
+
+- [API assessment](audit/2026-04-14-api-assessment.html): §8 actionable checklist, §9 document history, TOC entries for sections 7–9 (aligned with ADR 0024).
+
+- [DX assessment](audit/2026-04-14-documentation-experience-assessment.html): same section order as the API assessment; Table 2 anchor `table-2-study-app-scores`; invalid nesting and duplicate blocks removed.
+
+## <= 2026-04-12
 
 ### Changed
 
 - [ADR 0019](adr/0019-python-dependency-security-pip-audit-and-pinning-policy.html): implementation marked **Done** (`data-adr-weight="7"`). [Backlog item-4](backlog/README.html#item-4) marked **Done**; `Makefile` **`verify-ci`** now includes **`deps-audit`** (engineering-practices table synced).
 
 - [ADR 0022](adr/0022-embedded-swagger-ui-openapi-sandbox.html) superseded: browser validation cancelled; `openapi-explorer.html` is OpenAPI (test), Swagger browse-only; task on hold. Removed `openapi-live.html` (use app `/docs` for Try it out).
-
-### Added
-
-- [ADR 0021](adr/0021-continuous-delivery-github-actions-and-ghcr.html): continuous delivery via GitHub Actions — build <code>Dockerfile</code>, push to GHCR after CI, beginner-oriented context (CI vs CD), scope, and references; developer guide <a href="developer/0009-docker-and-kubernetes-local.html">0009</a> links to registry automation.
-
-- [ADR 0019](adr/0019-python-dependency-security-pip-audit-and-pinning-policy.html): Python dependency security—`requirements.txt` as exact pin, `pip-audit`, Make/CI expectations, severity handling, and exception process (implements backlog policy; `make deps-audit` / CI wiring tracked there).
-
-- Documentation changelog (`docs/CHANGELOG.md`) and ADR lifecycle policy ([ADR 0018](adr/0018-adr-lifecycle-ratification-and-badges.html)): Issue discussion with `[ADR]` title, ratification via Issue + PR, `data-adr-weight`, and `docs/CHANGELOG.md` update expectations.
-
-- [ADR 0020](adr/0020-c4-plantuml-diagram-style-and-conventions.html): C4 views, PlantUML layout and naming conventions, and a shared diagram style via `docs/uml/include/style.puml` (with `docs/uml/README.txt` for authors).
-
-### Changed
 
 - All numbered ADRs (`0001`–`0017`): replaced legacy **Status** badge blocks with `data-adr-weight="7"` on `<main>` and a **Ratification** note for pre–ADR-0018 adoption; UI status comes from `docs/assets/docs-nav.js` per [ADR 0018](adr/0018-adr-lifecycle-ratification-and-badges.html). [ADR 0018](adr/0018-adr-lifecycle-ratification-and-badges.html) and [ADR 0019](adr/0019-python-dependency-security-pip-audit-and-pinning-policy.html) include the collapsible weight help from the [ADR template](adr/0000-template.html).
 
@@ -39,3 +44,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - PlantUML under `docs/uml/`: architecture and sequence `.puml` sources include the shared style; rendered PNGs in `docs/uml/rendered/` updated to match ([ADR 0020](adr/0020-c4-plantuml-diagram-style-and-conventions.html)).
 
 - Docs pipeline and contributor entrypoints: `scripts/regenerate_docs.py`, `scripts/sync_docs.py`, `Makefile`, `CONTRIBUTING.md`, and `.github/ISSUE_TEMPLATE/adr_discussion.md` aligned with ADR lifecycle, UML rendering, and synced HTML companions (`docs/engineering-practices.html`, `docs/system-analysis.html`, `docs/backlog/README.html`, `docs/runbooks/README.html`, `docs/developer/0008-docs-pipeline.html`).
+
+
+### Added
+
+- [ADR 0021](adr/0021-continuous-delivery-github-actions-and-ghcr.html): continuous delivery via GitHub Actions — build <code>Dockerfile</code>, push to GHCR after CI, beginner-oriented context (CI vs CD), scope, and references; developer guide <a href="developer/0009-docker-and-kubernetes-local.html">0009</a> links to registry automation.
+
+- [ADR 0019](adr/0019-python-dependency-security-pip-audit-and-pinning-policy.html): Python dependency security—`requirements.txt` as exact pin, `pip-audit`, Make/CI expectations, severity handling, and exception process (implements backlog policy; `make deps-audit` / CI wiring tracked there).
+
+- Documentation changelog (`docs/CHANGELOG.md`) and ADR lifecycle policy ([ADR 0018](adr/0018-adr-lifecycle-ratification-and-badges.html)): Issue discussion with `[ADR]` title, ratification via Issue + PR, `data-adr-weight`, and `docs/CHANGELOG.md` update expectations.
+
+- [ADR 0020](adr/0020-c4-plantuml-diagram-style-and-conventions.html): C4 views, PlantUML layout and naming conventions, and a shared diagram style via `docs/uml/include/style.puml` (with `docs/uml/README.txt` for authors).

--- a/docs/adr/0024-architecture-and-quality-assessment-documents.html
+++ b/docs/adr/0024-architecture-and-quality-assessment-documents.html
@@ -1,0 +1,339 @@
+<!doctype html>
+<html lang="en">
+
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ADR 0024: Architecture and quality assessment documents (audit format)</title>
+    <link rel="stylesheet" href="../assets/docs.css" />
+    <script defer src="../assets/docs-nav.js"></script>
+  </head>
+
+  <body>
+    <main class="container" data-adr-weight="1">
+      <h1>ADR 0024: Architecture and quality assessment documents (audit format)</h1>
+      <div id="docs-top-nav"></div>
+      <details class="adr-weight-help">
+        <summary>ADR status on this page</summary>
+        <p class="small">
+          The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
+          <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
+          <a href="./0000-template.html">ADR template</a> for the full milestone table.
+        </p>
+      </details>
+
+      <h2>Ratification</h2>
+      <p>
+        This ADR records a <strong>process and format decision</strong> for assessment-style documents under
+        <code>docs/audit/</code>. Per <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a>, link the
+        discussion Issue (title prefixed <code>[ADR]</code>), merge PR, and acceptance date when the ratification thread
+        exists. Until then, the audit trail is the git history for this file on <code>main</code>.
+      </p>
+      <ul>
+        <li>Discussion Issue: <em>optional — link when opened with <code>[ADR]</code> title</em></li>
+        <li>Merge PR: <em>see git history for this file</em></li>
+        <li>Accepted: 2026-04-14</li>
+      </ul>
+
+      <h2>Context</h2>
+      <p>
+        <strong>Why this matters:</strong> Architecture Decision Records (<a href="./README.html">ADRs</a>) answer
+        <em>what we chose</em> and <em>why</em>. Runbooks answer <em>how to recover when something breaks</em>. Neither
+        format fits a third need: <strong>periodic, evidence-based evaluation</strong> of how well a subsystem matches
+        external reference practices — producing a dated snapshot (scope, methodology, scored dimensions, gaps, mitigation)
+        that can be revisited after refactors or releases.
+      </p>
+      <p>
+        Without a shared convention, assessment work drifts into one-off pages or chat summaries. This project already
+        treats documentation as a first-class artifact (<a href="./0001-docs-as-code.html">ADR 0001</a>) and governs HTTP
+        contracts (<a href="./0007-openapi-governance-and-usability-standard.html">ADR 0007</a>). <strong>Assessment
+        documents</strong> complement those policies: they <em>measure alignment</em> to reference practices and record
+        <em>what was reviewed, when, and with what result</em> — they do not replace ADRs.
+      </p>
+
+      <h3>Relationship to other doc types (summary)</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Artifact</th>
+            <th>Primary question</th>
+            <th>Typical owner</th>
+            <th>Update cadence</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>ADR</strong></td>
+            <td>What did we decide, and what do we trade off?</td>
+            <td>Engineering (with stakeholders as needed)</td>
+            <td>When the decision changes or is superseded</td>
+          </tr>
+          <tr>
+            <td><strong>Runbook</strong></td>
+            <td>What steps fix or mitigate an operational failure?</td>
+            <td>On-call / platform</td>
+            <td>When procedures or dependencies change</td>
+          </tr>
+          <tr>
+            <td><strong>Assessment (audit)</strong></td>
+            <td>How mature is area X vs reference practices, and what should we do next?</td>
+            <td>Tech lead, security, or docs/API owner (named in the document)</td>
+            <td>Periodic (e.g. yearly) or after major milestones</td>
+          </tr>
+          <tr>
+            <td><strong>Developer guide</strong></td>
+            <td>How do I work in this repo day to day?</td>
+            <td>Contributors</td>
+            <td>When workflows change</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Decision</h2>
+      <p>We adopt the following norms:</p>
+      <ol>
+        <li>
+          <strong>Location.</strong> Stand-alone assessment reports live under <code>docs/audit/</code> as static HTML
+          (same stack as other docs: <code>docs/assets/docs.css</code>, <code>docs/assets/docs-nav.js</code>).
+        </li>
+        <li>
+          <strong>Naming.</strong> Use the pattern
+          <code><var>YYYY-MM-DD</var>-<var>short-topic</var>-assessment.html</code>, all lowercase with hyphens in the
+          topic slug (example: <code>2026-04-14-api-assessment.html</code>). The ISO date is the <strong>assessment
+          date</strong> (when the review was performed or the document was last materially refreshed), not necessarily
+          the file creation date in git.
+        </li>
+        <li>
+          <strong>Format.</strong> Each assessment follows the <a href="#published-assessment-backbone">published
+          backbone</a> below unless the author documents a deliberate deviation in the lead block (e.g. a one-page
+          addendum).
+        </li>
+        <li>
+          <strong>Purpose.</strong> Assessments are for shared maturity understanding, traceability of what was checked,
+          prioritization of follow-ups, and onboarding of new leads. They are not a substitute for automated tests or
+          OpenAPI contract checks — they <strong>interpret</strong> results in a broader reference frame.
+        </li>
+        <li>
+          <strong>Scoring.</strong> When scores are used, they are <strong>indicative</strong> (1–10), defined in the
+          document, and tied to rows in a reference table. They are not performance ratings for individuals.
+        </li>
+        <li>
+          <strong>History.</strong> Each file includes a short <strong>Document history</strong> table so readers know what
+          changed between revisions without relying on git archaeology alone.
+        </li>
+      </ol>
+
+      <h2 id="assessment-score-scale">Assessment score scale (1–10) and shared legend</h2>
+      <p>
+        Table&nbsp;2 score cells use a <strong>single shared palette and legend</strong> so readers see the same semantics
+        on every assessment page. <strong>Colours and layout</strong> live in
+        <code>docs/assets/docs.css</code> (variables <code>--audit-score-*</code> and classes below). The only copy of the
+        legend <strong>markup</strong> is <code>docs/assets/audit-score-legend-fragment.html</code>. In assessment pages,
+        place a placeholder immediately before Table&nbsp;2:
+        <code>&lt;div class="audit-score-legend-include" data-legend-id="<var>suffix</var>"&gt;&lt;/div&gt;</code>
+        — <code>docs/assets/docs-nav.js</code> fetches the fragment and injects it. Use a short suffix (e.g.
+        <code>api</code>, <code>dx</code>) so the heading id becomes
+        <code>audit-score-legend-title-<var>suffix</var></code> when one document needs distinct labels; omit
+        <code>data-legend-id</code> to keep the default id <code>audit-score-legend-title</code>. For readers without
+        JavaScript, add a <code>&lt;noscript&gt;</code> note pointing to this ADR section.
+      </p>
+      <aside class="audit-score-legend" role="note" aria-labelledby="audit-score-legend-title-adr">
+        <h3 class="audit-score-legend-title" id="audit-score-legend-title-adr">Score scale (1–10)</h3>
+        <p class="audit-score-legend-intro">
+          Indicative maturity versus the reference practices in <em>this</em> document only. Not comparable across
+          unrelated assessments unless recalibrated. Does not rate individuals.
+        </p>
+        <ul class="audit-score-legend-bands">
+          <li>
+            <span class="audit-score-swatch score-excellent" aria-hidden="true"></span>
+            <span><strong>9–10 — Excellent.</strong> Strong fit for the stated scope (e.g. PET / small-team service where
+              that framing applies).</span>
+            </li>
+            <li>
+              <span class="audit-score-swatch score-good" aria-hidden="true"></span>
+              <span><strong>7–8 — Good.</strong> Solid, with clear room to improve.</span>
+            </li>
+            <li>
+              <span class="audit-score-swatch score-needs-attention" aria-hidden="true"></span>
+              <span><strong>1–6 — Needs attention.</strong> Missing, partial, narrow applicability, or below the reference
+                bar for this row.</span>
+              </li>
+            </ul>
+          </aside>
+          <p><strong>Score column CSS classes</strong> (apply to <code>&lt;td&gt;</code> in <code>table.audit-score-table</code>):</p>
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Class</th>
+                <th scope="col">Numeric band</th>
+                <th scope="col">Meaning (summary)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>score-excellent</code></td>
+                <td>9–10</td>
+                <td>Excellent — strong fit for scope.</td>
+              </tr>
+              <tr>
+                <td><code>score-good</code></td>
+                <td>7–8</td>
+                <td>Good — solid, clear improvements possible.</td>
+              </tr>
+              <tr>
+                <td><code>score-needs-attention</code></td>
+                <td>1–6</td>
+                <td>Needs attention — gaps vs reference bar. (<code>score-neutral</code> is a legacy alias; prefer
+                  <code>score-needs-attention</code>.)</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2 id="published-assessment-backbone">Published assessment backbone (normative)</h2>
+            <p>
+              The working templates in this repository are
+              <a href="../audit/2026-04-14-api-assessment.html"><code>2026-04-14-api-assessment.html</code></a> and
+              <a href="../audit/2026-04-14-documentation-experience-assessment.html"><code>2026-04-14-documentation-experience-assessment.html</code></a>.
+              New assessments should match their <strong>section order and intent</strong> (anchors and numbering may differ
+              slightly, e.g. optional “beyond baseline” only where useful).
+            </p>
+            <ol>
+              <li>
+                <strong>Title, nav chrome, lead (<code>class="lead"</code>).</strong> Lead must include assessment date, scope,
+                stack or constraints when relevant, and document purpose.
+              </li>
+              <li><strong>Table of contents</strong> — numbered <code>&lt;ol&gt;</code> linking to major <code>id</code>s.</li>
+              <li>
+                <strong>Scope and methodology</strong> — what was examined, method (often a short numbered list), and what the
+                assessment is not.
+              </li>
+              <li>
+                <strong>Table 1 — Reference practices.</strong> Neutral rubric: #, Category, Practice, Reference description,
+                Typical benchmark (wording may vary by topic).
+              </li>
+              <li>
+                <strong>Table 2 — Mapping and scores.</strong> One row per Table&nbsp;1 practice being scored; shared legend
+                placeholder immediately above the table (see <a href="#assessment-score-scale">score scale</a>); score cells
+                use the CSS classes above — no duplicated score rules in page-local <code>&lt;style&gt;</code>.
+              </li>
+              <li><strong>Scoring summary</strong> — overall read and themes toward “top decile” for that scope.</li>
+              <li>
+                <strong>Gaps, refactors, and recommendations</strong> — usually <strong>5.1</strong> should add,
+                <strong>5.2</strong> refactor/tighten, <strong>5.3</strong> nice-to-have; link to table rows where helpful.
+              </li>
+              <li><strong>Mitigation plan</strong> — phased or dated actions (indicative dates are fine).</li>
+              <li>
+                <strong>Optional — Beyond baseline / industry context</strong> — e.g. API assessment §7; omit when it would
+                only repeat Table&nbsp;1.
+              </li>
+              <li><strong>Actionable checklist</strong> — concise bullets tied to rows or sections for backlog/issues.</li>
+              <li><strong>Document history</strong> — <strong>Date | Change</strong>; substantive edits only (not trivial typos).</li>
+            </ol>
+
+            <h2>Scope of this ADR</h2>
+            <ul>
+              <li>
+                <strong>In scope:</strong> Files under <code>docs/audit/</code> that follow this backbone; cross-links from
+                <code>docs/index.html</code> or ADRs when an assessment is cited.
+              </li>
+              <li>
+                <strong>Out of scope:</strong> Confidential penetration-test reports (keep non-sensitive summaries elsewhere if
+                needed). Incident postmortems follow the incident process, not this ADR.
+              </li>
+            </ul>
+
+            <h2>Goals and process</h2>
+            <p>
+              <strong>Goals:</strong> institutional memory; shared vocabulary from Table&nbsp;1; prioritization via Table&nbsp;2
+              and mitigations; onboarding without a live walkthrough; traceability via lead + history.
+            </p>
+            <ul>
+              <li>
+                <strong>When to refresh:</strong> Major releases, security or API reviews, annual hygiene — or whenever scores or
+                conclusions change (update document history).
+              </li>
+              <li>
+                <strong>Ownership:</strong> The lead or an early section should imply an owner for follow-up triage (items may
+                land in <a href="../backlog/README.html">backlog</a>).
+              </li>
+              <li>
+                <strong>Linking:</strong> Prefer ADRs and runbooks over duplicating policy; assessments summarize and map.
+              </li>
+              <li>
+                <strong>Changelog:</strong> Add <code>docs/CHANGELOG.md</code> when adding or materially revising an assessment
+                (<a href="./0013-changelog-and-release-notes.html">ADR 0013</a>).
+              </li>
+            </ul>
+
+            <h2>Alternatives considered</h2>
+            <ol>
+              <li>
+                <strong>Markdown-only in <code>docs/</code>.</strong> Faster to draft; this site is HTML-first for many
+                handbooks. Companions are OK per <a href="../developer/0008-docs-pipeline.html">developer guide 0008</a>; the
+                <strong>canonical published assessment</strong> is HTML under <code>docs/audit/</code>.
+              </li>
+              <li>
+                <strong>Wiki or external tool only.</strong> Weakens docs-as-code review and exact commit/ADR linkage.
+              </li>
+              <li>
+                <strong>No separate assessments (ADRs only).</strong> ADRs do not naturally hold “we scored N practices”;
+                mixing would blur decisions vs evaluations.
+              </li>
+            </ol>
+
+            <h2>Consequences</h2>
+            <h3>Positive</h3>
+            <ul>
+              <li>Clear place and shape for maturity snapshots.</li>
+              <li>Easier prioritization with a visible rubric.</li>
+              <li>Consistent reader experience next to other <code>docs/</code> pages.</li>
+            </ul>
+            <h3>Trade-offs</h3>
+            <ul>
+              <li>Authors must maintain tables and history or the document misleads.</li>
+              <li>Scores invite debate; mitigate with scale definition, evidence, and no person-level use.</li>
+            </ul>
+
+            <h2>Compatibility and migration</h2>
+            <p>
+              No runtime impact. Existing <code>docs/audit/</code> files should converge on this backbone when edited. Rollback:
+              revert this ADR; assessments remain ordinary HTML.
+            </p>
+
+            <h2>Rollout and validation</h2>
+            <ul>
+              <li>Link this ADR from the ADR index; link <a href="../audit/README.html"><code>docs/audit/README.html</code></a> from <code>docs/index.html</code> and other doc hubs so readers can browse all assessments.</li>
+              <li>New assessments: copy a current audit file and replace Table&nbsp;1/2 and narrative sections.</li>
+              <li><strong>Technical:</strong> <code>make docs-check</code> passes after HTML changes.</li>
+              <li>
+                <strong>Human:</strong> A new reader can state what was reviewed, top gaps, and next steps from the assessment and
+                linked ADRs alone.
+              </li>
+              <li><strong>Documentation:</strong> <code>docs/CHANGELOG.md</code> updated for new or materially revised assessments.</li>
+            </ul>
+
+            <h2>References</h2>
+            <ul>
+              <li><a href="./0001-docs-as-code.html">ADR 0001</a> — Docs as Code.</li>
+              <li><a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> — ADR lifecycle and ratification.</li>
+              <li><a href="./0013-changelog-and-release-notes.html">ADR 0013</a> — Changelog policy (root vs docs).</li>
+              <li><a href="../developer/0008-docs-pipeline.html">Developer guide 0008</a> — Documentation pipeline.</li>
+              <li><a href="../assets/audit-score-legend-fragment.html">audit-score-legend-fragment.html</a> — legend markup (injected via <code>.audit-score-legend-include</code> in <code>docs-nav.js</code>).</li>
+              <li><a href="../assets/docs-nav.js"><code>docs-nav.js</code></a> — loads the fragment into assessment pages.</li>
+              <li><code>docs/assets/docs.css</code> — <code>--audit-score-*</code> and <code>.audit-score-*</code> rules.</li>
+              <li><a href="../audit/2026-04-14-api-assessment.html">API assessment</a> — reference layout.</li>
+              <li><a href="../audit/2026-04-14-documentation-experience-assessment.html">DX assessment</a> — same backbone, Documentation Experience topic.</li>
+            </ul>
+
+            <h2>HTML formatting note (repository tooling)</h2>
+            <p>
+              This ADR, <code>docs/assets/audit-score-legend-fragment.html</code>, and the assessment HTML files under
+              <code>docs/audit/</code> may be listed in <code>SKIP_HTML_INDENT_NORMALIZE</code> in
+              <code>scripts/format_docs_html.py</code> so the line-based HTML indenter does not rewrite them. That indenter can
+              mis-count nesting when block tags span multiple lines. Stylesheet and nav normalization still apply when you run
+              <code>make docs-fix</code> / <code>format_docs_html.py</code>.
+            </p>
+          </main>
+        </body>
+
+      </html>

--- a/docs/adr/README.html
+++ b/docs/adr/README.html
@@ -48,6 +48,8 @@
           </ul>
           <h3>Documentation &amp; diagrams</h3>
           <ul>
+            <li><a href="../audit/README.html">Assessment reports (index)</a> — all published audits under <code>docs/audit/</code>.</li>
+            <li><a href="./0024-architecture-and-quality-assessment-documents.html">ADR 0024</a> — assessment (audit) documents: location, HTML format, tables, scoring, process.</li>
             <li><a href="./0001-docs-as-code.html">ADR 0001</a> — docs in git, generation, quality gates.</li>
             <li><a href="./0013-changelog-and-release-notes.html">ADR 0013</a> — changelog at the root and PR rules.</li>
             <li><a href="./0016-python-docstrings-google-style-and-pdoc.html">ADR 0016</a> — docstrings and pdoc.</li>
@@ -248,6 +250,12 @@
                 <td>NDJSON logs, <code>X-Request-Id</code>, optional Docker Compose (Elasticsearch, Kibana, Filebeat) for local search—tracing in ES deferred to OpenTelemetry work.</td>
                 <td>Accepted</td>
                 <td><a href="./0023-structured-logging-and-local-elasticsearch.html">Open ADR 0023</a></td>
+              </tr>
+              <tr>
+                <td>ADR 0024</td>
+                <td>Architecture and quality assessments live under <code>docs/audit/</code> as dated HTML: reference table, mapping/scores, findings, mitigation, history—complementing ADRs and runbooks.</td>
+                <td>Accepted</td>
+                <td><a href="./0024-architecture-and-quality-assessment-documents.html">Open ADR 0024</a></td>
               </tr>
             </tbody>
           </table>

--- a/docs/assets/audit-score-legend-fragment.html
+++ b/docs/assets/audit-score-legend-fragment.html
@@ -1,0 +1,29 @@
+<!--
+Canonical Table 2 legend markup (single source of truth).
+Included at runtime: place <div class="audit-score-legend-include" data-legend-id="…"></div> before Table 2;
+docs/assets/docs-nav.js fetches this file. Optional suffix sets id audit-score-legend-title-<suffix>.
+Colours: docs/assets/docs.css. Policy: docs/adr/0024-architecture-and-quality-assessment-documents.html
+-->
+<aside class="audit-score-legend" role="note" aria-labelledby="audit-score-legend-title">
+  <h3 class="audit-score-legend-title" id="audit-score-legend-title">Score scale (1–10)</h3>
+  <p class="audit-score-legend-intro">
+    Indicative maturity versus the reference practices in <em>this</em> document only. Not comparable across unrelated
+    assessments unless recalibrated. Does not rate individuals.
+  </p>
+  <ul class="audit-score-legend-bands">
+    <li>
+      <span class="audit-score-swatch score-excellent" aria-hidden="true"></span>
+      <span><strong>9–10 — Excellent.</strong> Strong fit for the stated scope (e.g. PET / small-team service where that
+        framing applies).</span>
+      </li>
+      <li>
+        <span class="audit-score-swatch score-good" aria-hidden="true"></span>
+        <span><strong>7–8 — Good.</strong> Solid, with clear room to improve.</span>
+      </li>
+      <li>
+        <span class="audit-score-swatch score-needs-attention" aria-hidden="true"></span>
+        <span><strong>1–6 — Needs attention.</strong> Missing, partial, narrow applicability, or below the reference bar for
+          this row.</span>
+        </li>
+      </ul>
+    </aside>

--- a/docs/assets/docs-nav.js
+++ b/docs/assets/docs-nav.js
@@ -68,6 +68,9 @@ function activeTarget(relPath) {
   if (relPath.startsWith("runbooks/")) {
     return "runbooks/README.html";
   }
+  if (relPath.startsWith("audit/")) {
+    return "audit/README.html";
+  }
   if (relPath.startsWith("api/")) {
     return "api/index.html";
   }
@@ -96,6 +99,7 @@ function renderTopNav() {
     { label: "Developer Docs", target: "developer/README.html" },
     { label: "Backlog", target: "backlog/README.html" },
     { label: "ADR", target: "adr/README.html" },
+    { label: "Assessments", target: "audit/README.html" },
     { label: "Runbooks", target: "runbooks/README.html" },
     { label: "API (Python)", target: "api/index.html" },
     { label: "OpenAPI (test)", target: "openapi-explorer.html" },
@@ -264,10 +268,79 @@ function renderAdr(main) {
   renderAdrStatusLogAfter(anchor, globalMax);
 }
 
+/**
+ * Inject shared audit score legend from `assets/audit-score-legend-fragment.html` into
+ * `<div class="audit-score-legend-include" data-legend-id="optional-suffix"></div>`.
+ * One source of truth for markup; styles remain in docs.css (ADR 0024).
+ */
+function auditScoreLegendFragmentUrl() {
+  const relPath = currentDocsRelPath();
+  const fromDir = relPath.includes("/") ? relPath.slice(0, relPath.lastIndexOf("/")) : "";
+  return relHref(fromDir, "assets/audit-score-legend-fragment.html");
+}
+
+function stripLeadingHtmlComment(text) {
+  return text.replace(/^\s*<!--[\s\S]*?-->\s*/, "").trimStart();
+}
+
+function applyLegendIdSuffix(aside, suffix) {
+  const h3 = aside.querySelector(".audit-score-legend-title");
+  if (!h3) {
+    return;
+  }
+  if (suffix) {
+    const id = `audit-score-legend-title-${suffix}`;
+    h3.id = id;
+    aside.setAttribute("aria-labelledby", id);
+  }
+}
+
+async function injectAuditScoreLegends() {
+  const hosts = document.querySelectorAll(".audit-score-legend-include");
+  if (hosts.length === 0) {
+    return;
+  }
+
+  const url = auditScoreLegendFragmentUrl();
+  let htmlText;
+  try {
+    const res = await fetch(url, { credentials: "same-origin" });
+    if (!res.ok) {
+      throw new Error(`${res.status}`);
+    }
+    htmlText = await res.text();
+  } catch (e) {
+    for (const host of hosts) {
+      const err = document.createElement("p");
+      err.className = "audit-score-legend-error";
+      err.setAttribute("role", "alert");
+      err.textContent =
+        "Could not load the score legend. Open this site over HTTP(S) or see ADR 0024 for the scale.";
+      host.replaceWith(err);
+    }
+    return;
+  }
+
+  const cleaned = stripLeadingHtmlComment(htmlText);
+  const parsed = new DOMParser().parseFromString(cleaned, "text/html");
+  const templateAside = parsed.querySelector("aside.audit-score-legend");
+  if (!templateAside) {
+    return;
+  }
+
+  for (const host of hosts) {
+    const suffix = (host.getAttribute("data-legend-id") || "").trim();
+    const aside = document.importNode(templateAside, true);
+    applyLegendIdSuffix(aside, suffix);
+    host.replaceWith(aside);
+  }
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   renderTopNav();
   const main = document.querySelector("main.container");
   if (main) {
     renderAdr(main);
   }
+  injectAuditScoreLegends();
 });

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -8,6 +8,15 @@
   --muted: #4b5563;
   --accent: #2563eb;
   --line: #dbe3ef;
+  /* Assessment score bands (Table 2) — see ADR 0024, docs/assets/audit-score-legend-fragment.html */
+  --audit-score-excellent-bg: #d1e7dd;
+  --audit-score-excellent-border: #198754;
+  --audit-score-good-bg: #fff3cd;
+  --audit-score-good-border: #e0a800;
+  --audit-score-needs-bg: #f8d7da;
+  --audit-score-needs-border: #c82333;
+  --audit-score-legend-border: #dee2e6;
+  --audit-score-legend-bg: #f8f9fa;
 }
 
 * {
@@ -556,6 +565,116 @@ td {
 th {
   background: #f3f6fc;
   font-weight: 600;
+}
+
+/* Assessment Table 2 — score column + legend layout (normative copy: audit-score-legend-fragment.html; ADR 0024). */
+
+.audit-score-table td.score-excellent,
+.audit-score-table td.score-good,
+.audit-score-table td.score-needs-attention,
+.audit-score-table td.score-neutral {
+  font-weight: 600;
+  text-align: center;
+  border-left: 3px solid transparent;
+}
+
+.audit-score-table td.score-excellent {
+  background-color: var(--audit-score-excellent-bg);
+  border-left-color: var(--audit-score-excellent-border);
+}
+
+.audit-score-table td.score-good {
+  background-color: var(--audit-score-good-bg);
+  border-left-color: var(--audit-score-good-border);
+}
+
+/* 1–6 / gaps — same visual (alias: score-neutral kept for older HTML) */
+.audit-score-table td.score-needs-attention,
+.audit-score-table td.score-neutral {
+  background-color: var(--audit-score-needs-bg);
+  border-left-color: var(--audit-score-needs-border);
+}
+
+aside.audit-score-legend {
+  margin: 1rem 0 1.25rem;
+  padding: 0.85rem 1rem 1rem;
+  border: 1px solid var(--audit-score-legend-border);
+  border-radius: 8px;
+  background: var(--audit-score-legend-bg);
+}
+
+.audit-score-legend-title {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+  color: var(--text);
+}
+
+.audit-score-legend-intro {
+  margin: 0 0 0.65rem;
+  font-size: 0.92rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+ul.audit-score-legend-bands {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.audit-score-legend-bands li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  margin: 0.45rem 0 0;
+  line-height: 1.45;
+  font-size: 0.92rem;
+}
+
+.audit-score-swatch {
+  width: 1.15rem;
+  height: 1.15rem;
+  min-width: 1.15rem;
+  border-radius: 4px;
+  margin-top: 0.15rem;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-sizing: border-box;
+}
+
+.audit-score-swatch.score-excellent {
+  background: var(--audit-score-excellent-bg);
+  border-color: var(--audit-score-excellent-border);
+}
+
+.audit-score-swatch.score-good {
+  background: var(--audit-score-good-bg);
+  border-color: var(--audit-score-good-border);
+}
+
+.audit-score-swatch.score-needs-attention {
+  background: var(--audit-score-needs-bg);
+  border-color: var(--audit-score-needs-border);
+}
+
+/* Placeholder before docs-nav.js injects the legend from audit-score-legend-fragment.html */
+.audit-score-legend-include {
+  min-height: 1px;
+}
+
+p.audit-score-legend-noscript,
+p.audit-score-legend-error {
+  margin: 0.75rem 0;
+  padding: 0.65rem 0.85rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+  background: #fff8e6;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+}
+
+p.audit-score-legend-error {
+  background: #fde8e8;
+  color: #7f1d1d;
 }
 
 /* openapi-explorer.html — OpenAPI (test), Swagger UI browse-only */

--- a/docs/audit/2026-04-14-api-assessment.html
+++ b/docs/audit/2026-04-14-api-assessment.html
@@ -1,0 +1,925 @@
+<!doctype html>
+<html lang="en">
+
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>REST API Assessment — Study App (14 Apr 2026)</title>
+    <link rel="stylesheet" href="../assets/docs.css" />
+    <script defer src="../assets/docs-nav.js"></script>
+  </head>
+
+  <body>
+    <main class="container">
+      <h1>REST API Assessment — Study App</h1>
+      <div id="docs-top-nav"></div>
+      <p class="lead">
+        <strong>Assessment date:</strong> 14 April 2026<br />
+        <strong>Stack:</strong> Python 3.x, FastAPI, SQLAlchemy<br />
+        <strong>API surface:</strong> Versioned HTTP API under <code>/api/v1</code> (e.g. User resources)<br />
+        <strong>Document purpose:</strong> Record what was reviewed, how it maps to industry practices, maturity scoring,
+        gaps, a mitigation plan, and how “top-tier” companies structure APIs and documentation beyond baseline
+        OpenAPI.<br />
+      </p>
+
+      <section>
+        <h2 id="table-of-contents">Table of contents</h2>
+        <ol>
+          <li><a href="#1-scope-and-methodology">Scope and methodology</a></li>
+          <li><a href="#table-1-reference-practices">Table 1 — Reference practices</a></li>
+          <li><a href="#table-2-study-app-scores">Table 2 — Study App implementation and scores</a></li>
+          <li><a href="#4-scoring-summary">Scoring summary</a></li>
+          <li><a href="#5-gaps-refactors-and-recommendations">Gaps, refactors, and recommendations</a></li>
+          <li><a href="#6-mitigation-plan-and-indicative-deadlines">Mitigation plan and indicative deadlines</a></li>
+          <li><a href="#7-beyond-baseline-how-top-companies-treat-openapi-and-swagger">Beyond baseline: OpenAPI and
+            “Swagger”</a></li>
+            <li><a href="#document-history">Document history</a></li>
+          </ol>
+        </section>
+
+        <section>
+          <h2 id="1-scope-and-methodology">1. Scope and methodology</h2>
+
+          <h3 id="1-1-scope">1.1 Scope</h3>
+          <p>
+            This assessment covers the <strong>Study App</strong> HTTP API as implemented in this repository: runtime
+            behaviour, contract surface (OpenAPI), operational endpoints, security defaults, observability hooks, and CI
+            governance around the public contract. It is written for engineers and technical stakeholders evaluating how
+            close
+            the service is to common “platform API” expectations for a <strong>small / PET-scale</strong> deployment (single
+            service, not a multi-region gateway product).
+          </p>
+          <p>
+            The <strong>User</strong> resource under <code>/api/v1</code> is the primary worked example; patterns (e.g.
+            idempotency, errors) apply to other routes that follow the same conventions. Features described only as
+            industry reference (e.g. <code>ETag</code>/<code>If-Match</code>) are marked as such when they are
+            <strong>not</strong> implemented in the current code.
+          </p>
+
+          <h3 id="1-2-method">1.2 Method</h3>
+          <p>The review proceeds in four steps:</p>
+          <ol>
+            <li>
+              <strong>Reference catalogue</strong> — Table&nbsp;1 lists HTTP/API and OpenAPI-related practices with neutral
+              descriptions (what “good” usually means).
+            </li>
+            <li>
+              <strong>Implementation mapping</strong> — Table&nbsp;2 scores each practice (1–10) against the
+              <strong>current</strong> codebase and repository artifacts, with evidence pointers (paths, tools, ADRs).
+            </li>
+            <li>
+              <strong>Synthesis</strong> — short overall score, gaps grouped by priority, and a mitigation timeline with
+              indicative dates.
+            </li>
+            <li>
+              <strong>Industry context and follow-ups</strong> — optional narrative (e.g. “beyond baseline” OpenAPI/DX),
+              then a short actionable checklist and document history (see TOC).
+            </li>
+          </ol>
+          <p>
+            Scores are <strong>subjective</strong> and comparative (PET / integration-API lens), not a certification audit.
+            They reward consistency, documentation, and automation; they penalise missing scale features only where the gap
+            matters for stated multi-instance or external-integrator scenarios.
+          </p>
+
+          <h3 id="1-3-what-was-examined">1.3 What was examined</h3>
+          <ul>
+            <li>
+              Application entrypoint and middleware (<code>app/main.py</code>): request logging, body size limits,
+              authentication, rate limiting, security headers, request context.
+            </li>
+            <li>
+              Correlation identifiers (<code>app/core/request_context.py</code>, <code>app/core/logging.py</code>).
+            </li>
+            <li>
+              Write idempotency (<code>app/core/idempotency.py</code>,
+              <code>app/repositories/idempotency_repository.py</code>, user routes).
+            </li>
+            <li>
+              API contract and documentation pipeline: OpenAPI generation, custom builder, Swagger UI,
+              <code>app/openapi/</code>, baseline and governance scripts.
+            </li>
+            <li>
+              Configuration and deployment hints (<code>app/core/config.py</code>, <code>env/</code>, <code>k8s/</code>).
+            </li>
+            <li>
+              Quality gates relevant to the API contract: <code>Makefile</code> targets,
+              <code>.github/workflows/ci.yml</code>,
+              OpenAPI baseline and contract tests.
+            </li>
+          </ul>
+
+          <h3 id="1-4-what-this-assessment-is-not">1.4 What this assessment is not</h3>
+          <ul>
+            <li>It is not a full penetration test, formal compliance audit, or threat model.</li>
+            <li>It does not certify production readiness or fitness for a specific regulatory regime.</li>
+            <li>It does not replace load testing, chaos testing, or user research with real integrators.</li>
+          </ul>
+
+          <h3 id="1-5-code-snapshot">1.5 Code snapshot assumptions</h3>
+          <p>
+            Tables and narrative reflect the repository <strong>as reviewed</strong> for this assessment date. If behaviour
+            changes (new routes, removed headers, different auth), update Table&nbsp;2 and the scoring summary accordingly.
+            At the time of writing, the User API exposes create / read / update / patch by composite key; there is no
+            collection list endpoint, so pagination practices are noted as not applicable yet rather than “missing without
+            context.”
+          </p>
+        </section>
+
+        <section id="summary-practice-tables">
+          <h2 id="table-1-reference-practices">2. Table: Reference practices (HTTP/API + OpenAPI/DX “beyond baseline”)</h2>
+          <p>
+            Detailed list of REST/HTTP practices and OpenAPI/DX practices. Used as a reference for the
+            assessment.
+            <br><strong>Category</strong> groups the theme; <strong>Reference description</strong> states expected
+            behaviour without tying the narrative to a particular stack.
+            <br><strong>Typical benchmark</strong> is a company that is known for its best-in-class API practices.
+          </p>
+          <div style="overflow-x: auto">
+            <table class="audit-ref-table">
+              <thead>
+                <tr>
+                  <th scope="col">#</th>
+                  <th scope="col">Category</th>
+                  <th scope="col">Practice</th>
+                  <th scope="col">Reference description</th>
+                  <th scope="col">Typical benchmark</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>1</td>
+                  <td>Correlation</td>
+                  <td>Request identifier</td>
+                  <td>
+                    Every HTTP request gets a stable id; often echoed as <code>X-Request-Id</code>; the same value appears
+                    in
+                    structured logs and (when present) in traces.
+                  </td>
+                  <td>Minimum bar for support and incidents.</td>
+                </tr>
+                <tr>
+                  <td>2</td>
+                  <td>Write reliability</td>
+                  <td>Idempotent <code>POST</code></td>
+                  <td>
+                    <code>Idempotency-Key</code> header + operation scope + body hash; retries return the stored outcome;
+                    same key with a different body yields a predictable <code>409</code> with a machine-readable code.
+                  </td>
+                  <td>Stripe/Twilio-level expectation for payment and write APIs.</td>
+                </tr>
+                <tr>
+                  <td>3</td>
+                  <td>Concurrency</td>
+                  <td>Optimistic locking (<code>ETag</code> / <code>If-Match</code>)</td>
+                  <td>
+                    <code>GET</code> returns an <code>ETag</code>; <code>PUT</code>/<code>PATCH</code> send
+                    <code>If-Match</code>; if the resource changed, respond <code>412 Precondition Failed</code>.
+                  </td>
+                  <td>Avoids “last writer wins” without coordination.</td>
+                </tr>
+                <tr>
+                  <td>4</td>
+                  <td>Reads</td>
+                  <td>Conditional <code>GET</code> (<code>304</code>)</td>
+                  <td>
+                    Client sends <code>If-None-Match</code>; if unchanged, respond <code>304 Not Modified</code> with no
+                    body.
+                  </td>
+                  <td>Saves bandwidth for polling clients.</td>
+                </tr>
+                <tr>
+                  <td>5</td>
+                  <td>Collections</td>
+                  <td>Pagination (cursor / keyset)</td>
+                  <td>
+                    For large lists, use a cursor or “after this key” rather than deep <code>OFFSET</code>; stable under
+                    concurrent writes.
+                  </td>
+                  <td>Public list APIs for large catalogs.</td>
+                </tr>
+                <tr>
+                  <td>6</td>
+                  <td>API evolution</td>
+                  <td>URL versioning + compatibility policy</td>
+                  <td>
+                    Major version prefix (e.g. <code>/api/v1</code>); additive vs breaking rules; deprecation window.
+                  </td>
+                  <td>Many clients on one backend.</td>
+                </tr>
+                <tr>
+                  <td>7</td>
+                  <td>Errors</td>
+                  <td>Unified error contract</td>
+                  <td>
+                    Stable <code>code</code>/<code>key</code>; for 422, structured field list; optionally RFC 7807
+                    (<code>application/problem+json</code>).
+                  </td>
+                  <td>Clients branch on codes, not prose.</td>
+                </tr>
+                <tr>
+                  <td>8</td>
+                  <td>Access</td>
+                  <td>Authentication and rate limiting</td>
+                  <td>
+                    Explicit scheme (API key, OAuth, etc.); on quota exceed, <code>429</code>, <code>Retry-After</code>,
+                    <code>X-RateLimit-*</code>; in clusters, shared counter storage.
+                  </td>
+                  <td>Protection and fair consumption.</td>
+                </tr>
+                <tr>
+                  <td>9</td>
+                  <td>Security</td>
+                  <td>Limits and headers</td>
+                  <td>
+                    Request body size limits; CSP and related security headers; sensible CORS; no secrets in logs.
+                  </td>
+                  <td>Baseline hygiene before WAF/mTLS at the edge.</td>
+                </tr>
+                <tr>
+                  <td>10</td>
+                  <td>Observability</td>
+                  <td>Logs, metrics, probes</td>
+                  <td>
+                    Structured logs (JSON); metrics (e.g. Prometheus); <code>/live</code> and <code>/ready</code>; tracing
+                    via
+                    W3C/OpenTelemetry as services multiply.
+                  </td>
+                  <td>SRE and 24/7 operations.</td>
+                </tr>
+                <tr>
+                  <td>11</td>
+                  <td>Tracing</td>
+                  <td><code>traceparent</code> / OpenTelemetry</td>
+                  <td>
+                    Ingress context ties logs and spans together; OTLP export to a tracing backend.
+                  </td>
+                  <td>Standard for microservices and platforms.</td>
+                </tr>
+                <tr>
+                  <td>12</td>
+                  <td>Contract</td>
+                  <td>OpenAPI as source of truth</td>
+                  <td>
+                    <code>operationId</code>, success and error examples, tags, <code>securitySchemes</code>, documented
+                    headers (request id, rate limits).
+                  </td>
+                  <td>SDK generation and one truth for teams.</td>
+                </tr>
+                <tr>
+                  <td>13</td>
+                  <td>CI</td>
+                  <td>Anti-drift for the spec</td>
+                  <td>
+                    Completeness checks (e.g. examples on writes and 422), semantic compare to a baseline, optional strict
+                    byte-for-byte mode.
+                  </td>
+                  <td>As in this repo: <code>openapi-check</code>, <code>contract-test</code>.</td>
+                </tr>
+                <tr>
+                  <td>14</td>
+                  <td>DX (Documentation Experience)</td>
+                  <td>Interactive help</td>
+                  <td>
+                    Swagger UI or equivalent at runtime; optional static page with an OpenAPI snapshot for browsing without
+                    a server.
+                  </td>
+                  <td>Fast manual API calls.</td>
+                </tr>
+                <tr>
+                  <td>15</td>
+                  <td>DX (Documentation Experience)</td>
+                  <td>Developer portal</td>
+                  <td>
+                    More than live docs: navigation, brand, onboarding journeys; OpenAPI is one artifact, not the whole UX.
+                  </td>
+                  <td>Large API-first companies.</td>
+                </tr>
+                <tr>
+                  <td>16</td>
+                  <td>DX (Documentation Experience)</td>
+                  <td>Reference vs guides</td>
+                  <td>
+                    Machine reference docs separate from human guides (scenarios, best practices).
+                  </td>
+                  <td>Stripe / Twilio style.</td>
+                </tr>
+                <tr>
+                  <td>17</td>
+                  <td>DX (Documentation Experience)</td>
+                  <td>Premium documentation patterns</td>
+                  <td>
+                    Layout that supports scanning (e.g. three columns), multi-language examples, search across guides and
+                    reference, CI-tested examples, personalized keys in snippets.
+                  </td>
+                  <td>See section 7.2 of this document.</td>
+                </tr>
+                <tr>
+                  <td>18</td>
+                  <td>Spec distribution</td>
+                  <td>Stable URL and discovery</td>
+                  <td>
+                    Public <code>openapi.json</code>, sometimes <code>.well-known</code>;
+                    <code>latest</code>/<code>preview</code>
+                    variants in a repo.
+                  </td>
+                  <td>Integrators and codegen without guessing URLs.</td>
+                </tr>
+                <tr>
+                  <td>19</td>
+                  <td>Specification</td>
+                  <td>Overlays</td>
+                  <td>
+                    Overlays on canonical OpenAPI for branding/navigation without forking the schema.
+                  </td>
+                  <td>Large specs and multi-brand.</td>
+                </tr>
+                <tr>
+                  <td>20</td>
+                  <td>Governance</td>
+                  <td>Extended lint (Spectral, etc.)</td>
+                  <td>
+                    Style rules for naming, pagination, errors, security—beyond minimal baseline checks.
+                  </td>
+                  <td>Internal style guides (AIP-like).</td>
+                </tr>
+                <tr>
+                  <td>21</td>
+                  <td>Events</td>
+                  <td>AsyncAPI</td>
+                  <td>
+                    Separate specification for webhooks/streams alongside REST.
+                  </td>
+                  <td>Complex asynchronous contracts.</td>
+                </tr>
+                <tr>
+                  <td>22</td>
+                  <td>Errors</td>
+                  <td>Error catalog</td>
+                  <td>
+                    Dedicated pages or sections for error codes beyond inline OpenAPI descriptions.
+                  </td>
+                  <td>Twilio-style error reference.</td>
+                </tr>
+                <tr>
+                  <td>23</td>
+                  <td>Lifecycle</td>
+                  <td>Changelog and deprecations</td>
+                  <td>
+                    Keep a Changelog; HTTP <code>Deprecation</code> / <code>Sunset</code> when sunsetting; minimum support
+                    window.
+                  </td>
+                  <td>Trust from external integrators.</td>
+                </tr>
+                <tr>
+                  <td>24</td>
+                  <td>Platform</td>
+                  <td>Single artifact pipeline</td>
+                  <td>
+                    One specification feeds docs, contract tests, mocks, and (when needed) SDKs.
+                  </td>
+                  <td>Mature API platforms.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h2 id="table-2-study-app-scores">3. Table: Practice — Study App implementation — score (1–10)</h2>
+          <div class="audit-score-legend-include" data-legend-id="api"></div>
+          <noscript>
+            <p class="audit-score-legend-noscript">
+              Legend text lives in <code>docs/assets/audit-score-legend-fragment.html</code> (loaded by
+              <code>docs-nav.js</code> when JavaScript is on). See
+              <a href="../adr/0024-architecture-and-quality-assessment-documents.html#assessment-score-scale">ADR 0024</a>
+              for the scale.
+            </p>
+          </noscript>
+          <div style="overflow-x: auto">
+            <table class="audit-score-table">
+              <thead>
+                <tr>
+                  <th scope="col">#</th>
+                  <th scope="col">Practice</th>
+                  <th scope="col">What exists in the project (code)</th>
+                  <th scope="col">Score</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>1</td>
+                  <td>Request identifier</td>
+                  <td>
+                    Middleware normalizes/generates an id, <code>X-Request-Id</code> on the response, context in JSON logs
+                    (<code>app/core/request_context.py</code>, <code>app/core/logging.py</code>).
+                  </td>
+                  <td class="score-excellent">9</td>
+                </tr>
+                <tr>
+                  <td>2</td>
+                  <td>Idempotent <code>POST</code> (writes)</td>
+                  <td>
+                    <code>Idempotency-Key</code>, <code>idempotency_keys</code> table, payload hash, <code>409</code> on
+                    conflict; OpenAPI examples (<code>app/core/idempotency.py</code>, user routes).
+                  </td>
+                  <td class="score-excellent">9</td>
+                </tr>
+                <tr>
+                  <td>3</td>
+                  <td><code>ETag</code> / <code>If-Match</code></td>
+                  <td>
+                    <strong>Not implemented</strong> on current routes (no optimistic-locking headers on
+                    <code>PUT</code>/<code>PATCH</code>).
+                  </td>
+                  <td class="score-needs-attention">3</td>
+                </tr>
+                <tr>
+                  <td>4</td>
+                  <td>Conditional <code>GET</code> (<code>304</code>)</td>
+                  <td>Not implemented for <code>GET /api/v1/user/…</code>.</td>
+                  <td class="score-needs-attention">2</td>
+                </tr>
+                <tr>
+                  <td>5</td>
+                  <td>Collection pagination</td>
+                  <td>
+                    User API has <strong>no</strong> list endpoint; the practice becomes relevant if collection reads are
+                    added.
+                  </td>
+                  <td class="score-needs-attention">4</td>
+                </tr>
+                <tr>
+                  <td>6</td>
+                  <td>URL version + policy</td>
+                  <td>
+                    Router under <code>/api/v1</code>; policy in ADR 0004; OpenAPI <code>servers</code> skew toward local
+                    development.
+                  </td>
+                  <td class="score-excellent">9</td>
+                </tr>
+                <tr>
+                  <td>7</td>
+                  <td>Unified error contract</td>
+                  <td>
+                    Stable <code>code</code>/<code>key</code>, custom envelope (not RFC 7807 by default), rich OpenAPI
+                    examples;
+                    error matrix in docs.
+                  </td>
+                  <td class="score-good">8</td>
+                </tr>
+                <tr>
+                  <td>8</td>
+                  <td>Authentication and rate limiting</td>
+                  <td>
+                    API key, in-memory limiter, <code>429</code> with <code>Retry-After</code> and
+                    <code>X-RateLimit-*</code>;
+                    quotas are not global across replicas without Redis/gateway.
+                  </td>
+                  <td class="score-good">7</td>
+                </tr>
+                <tr>
+                  <td>9</td>
+                  <td>Limits and security headers</td>
+                  <td>
+                    Request body size limit, CORS from config, security headers middleware
+                    (<code>app/core/security.py</code>).
+                  </td>
+                  <td class="score-good">8</td>
+                </tr>
+                <tr>
+                  <td>10</td>
+                  <td>Logs, metrics, probes</td>
+                  <td>
+                    NDJSON logs, Prometheus metrics, <code>/live</code>, <code>/ready</code> with DB check, optional
+                    Elasticsearch/Filebeat for local search.
+                  </td>
+                  <td class="score-excellent">9</td>
+                </tr>
+                <tr>
+                  <td>11</td>
+                  <td><code>traceparent</code> / OpenTelemetry</td>
+                  <td>
+                    <code>trace_id</code>/<code>span_id</code> fields reserved in logs; full OTel integration not present.
+                  </td>
+                  <td class="score-needs-attention">4</td>
+                </tr>
+                <tr>
+                  <td>12</td>
+                  <td>Runtime OpenAPI contract</td>
+                  <td>
+                    Tags, <code>operationId</code>, examples, <code>custom_openapi</code> documenting
+                    <code>X-Request-Id</code> per operation.
+                  </td>
+                  <td class="score-excellent">9</td>
+                </tr>
+                <tr>
+                  <td>13</td>
+                  <td>CI against OpenAPI drift</td>
+                  <td>
+                    <code>scripts/openapi_governance.py</code>, baseline <code>docs/openapi/openapi-baseline.json</code>,
+                    <code>make openapi-check</code> / <code>contract-test</code>, CI steps.
+                  </td>
+                  <td class="score-excellent">9</td>
+                </tr>
+                <tr>
+                  <td>14</td>
+                  <td>Interactive help</td>
+                  <td>
+                    <code>/docs</code> (Swagger UI) in the app; static <code>docs/openapi-explorer.html</code> over a spec
+                    snapshot.
+                  </td>
+                  <td class="score-good">8</td>
+                </tr>
+                <tr>
+                  <td>15</td>
+                  <td>Developer portal</td>
+                  <td>
+                    No separate marketing portal; HTML docs, ADRs, indexes—“docs as repo” level.
+                  </td>
+                  <td class="score-needs-attention">5</td>
+                </tr>
+                <tr>
+                  <td>16</td>
+                  <td>Reference vs guides</td>
+                  <td>
+                    Split: pdoc/OpenAPI vs <code>docs/developer/*</code>, engineering practices, runbooks—no single
+                    three-column portal.
+                  </td>
+                  <td class="score-good">7</td>
+                </tr>
+                <tr>
+                  <td>17</td>
+                  <td>Premium patterns (columns, SDKs, search, tested snippets)</td>
+                  <td>
+                    Partial: search in generated API docs, curl examples in operation descriptions; no multi-language SDKs
+                    from
+                    the spec, no personalized keys in snippets.
+                  </td>
+                  <td class="score-needs-attention">4</td>
+                </tr>
+                <tr>
+                  <td>18</td>
+                  <td>Stable public spec URL</td>
+                  <td>
+                    <code>/openapi.json</code> from the app; optional <code>.well-known</code> not standardized; baseline in
+                    git
+                    for partners/CI.
+                  </td>
+                  <td class="score-good">7</td>
+                </tr>
+                <tr>
+                  <td>19</td>
+                  <td>OpenAPI overlays</td>
+                  <td>Not used.</td>
+                  <td class="score-needs-attention">2</td>
+                </tr>
+                <tr>
+                  <td>20</td>
+                  <td>Spectral / external spec lint</td>
+                  <td>
+                    Custom governance script and pytest contract tests; does not replicate a full Spectral ruleset.
+                  </td>
+                  <td class="score-good">7</td>
+                </tr>
+                <tr>
+                  <td>21</td>
+                  <td>AsyncAPI</td>
+                  <td>None (REST-only surface).</td>
+                  <td class="score-needs-attention">2</td>
+                </tr>
+                <tr>
+                  <td>22</td>
+                  <td>Error catalog</td>
+                  <td>
+                    Error matrix and OpenAPI examples; no standalone public “error center” like Twilio.
+                  </td>
+                  <td class="score-good">7</td>
+                </tr>
+                <tr>
+                  <td>23</td>
+                  <td>Changelog and HTTP deprecations</td>
+                  <td>
+                    <code>CHANGELOG.md</code> with CI gate; <code>Deprecation</code>/<code>Sunset</code> response headers
+                    not
+                    implemented.
+                  </td>
+                  <td class="score-good">7</td>
+                </tr>
+                <tr>
+                  <td>24</td>
+                  <td>Single artifact pipeline</td>
+                  <td>
+                    OpenAPI generated from FastAPI; baseline in repo; tests and verify tied to contract; no SDK generation.
+                  </td>
+                  <td class="score-good">8</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section>
+          <h2 id="4-scoring-summary">4. Scoring summary</h2>
+          <p>
+            <strong>Overall (subjective, integration-API scenario):</strong> approximately <strong>7 / 10</strong> on the
+            1–10 scale.
+            <br><strong>To approach top decile:</strong> distributed limits, tracing, explicit deprecation headers,
+            optional
+            conditional GETs / ETag if product needs safe concurrent edits, and deeper DX (portal, Spectral, stable
+            discovery URLs).
+          </p>
+        </section>
+
+        <section>
+          <h2 id="5-gaps-refactors-and-recommendations">5. Gaps, refactors, and recommendations</h2>
+          <p>
+            Grouped by implementation priority. Row numbers refer to
+            <a href="#table-1-reference-practices">Table 1</a> where helpful.
+          </p>
+
+          <h3 id="5-1-should-add">5.1 Should add</h3>
+          <p><em>High impact for moderate effort; closes main gaps in Table 2.</em></p>
+          <ol>
+            <li>
+              <strong>OpenTelemetry / <code>traceparent</code></strong> (Table 1–2, row 11): span export; populate
+              <code>trace_id</code>/<code>span_id</code> in logs.
+            </li>
+            <li>
+              <strong>Distributed rate limiting</strong> or edge policy (row 8): Redis / API gateway when running &gt;1
+              replica.
+            </li>
+            <li>
+              <strong>HTTP deprecation / sunset</strong> (row 23): response headers plus the existing changelog gate.
+            </li>
+            <li>
+              <strong>Optional:</strong> stable spec discovery—<code>.well-known</code> or a documented public URL (row 18).
+            </li>
+            <li>
+              <strong>If collections are added:</strong> cursor/keyset pagination (row 5).
+            </li>
+            <li>
+              <strong>If concurrent edits matter:</strong> <code>ETag</code>/<code>If-Match</code> (row 3).
+            </li>
+          </ol>
+
+          <h3 id="5-2-should-refactor">5.2 Should refactor / tighten</h3>
+          <p><em>Improve consistency without changing the domain model.</em></p>
+          <ol>
+            <li>
+              <strong>One convention</strong> for idempotency scope strings (<code>endpoint_path</code>) across all writes
+              as
+              the API grows.
+            </li>
+            <li>
+              <strong>OpenAPI <code>servers</code>:</strong> add staging/production once environments are fixed (today skews
+              to localhost).
+            </li>
+            <li>
+              <strong>Application version:</strong> single source (e.g. <code>pyproject.toml</code>) instead of drift
+              between
+              <code>FastAPI(version=…)</code> and releases (see backlog item 22).
+            </li>
+            <li>
+              <strong>Runbooks:</strong> state explicitly that in-memory limits do not aggregate across workers/pods.
+            </li>
+          </ol>
+
+          <h3 id="5-3-nice-to-have">5.3 Nice-to-have (product-dependent)</h3>
+          <p><em>Worth it for external integrators, SDKs, or an event-driven surface.</em></p>
+          <ol>
+            <li><strong>Spectral / Redocly CLI</strong> alongside <code>openapi_governance.py</code> (row 20).</li>
+            <li><strong>RFC 7807</strong> in parallel with the current envelope for new clients (row 7).</li>
+            <li><strong>OAuth2/OIDC</strong> instead of or in addition to API keys for user-facing apps (row 8).</li>
+            <li><strong>AsyncAPI</strong> when webhooks/queues appear (row 21).</li>
+            <li>
+              <strong>Standalone developer portal</strong> (Redocly/Stoplight-class) and multi-language snippets (rows
+              15–17).
+            </li>
+            <li>
+              <strong>Conditional <code>GET</code> <code>304</code></strong> for hot reads if load patterns justify it (row
+              4).
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h2 id="6-mitigation-plan-and-indicative-deadlines">6. Mitigation plan and indicative deadlines</h2>
+          <p>Dates are <strong>indicative</strong>; keep order if timelines slip.</p>
+
+          <div class="card">
+            <h3 id="phase-a">Phase A — by <strong>30 April 2026</strong></h3>
+            <ul>
+              <li>
+                Normalize idempotency operation identifiers (one documented format; DB migration if needed).
+              </li>
+              <li>Document in-memory rate limit limitation for horizontal scaling in runbooks / this audit.</li>
+              <li>
+                Keep <strong>OpenAPI baseline</strong> checks in CI strict: any contract change is an intentional snapshot
+                update.
+              </li>
+            </ul>
+          </div>
+
+          <div class="card">
+            <h3 id="phase-b">Phase B — <strong>1 May – 30 June 2026</strong></h3>
+            <ul>
+              <li>
+                Implement <strong>conditional GET</strong> (<code>If-None-Match</code> / <code>304</code>) for at least
+                primary <code>GET</code> resources.
+              </li>
+              <li>
+                <strong>Distributed rate limiting</strong>: design + implementation (Redis or gateway); preserve
+                <code>X-RateLimit-*</code> and <code>Retry-After</code>.
+              </li>
+              <li>
+                <strong>Draft deprecation policy</strong>: headers, changelog, minimum notice for consumers.
+              </li>
+            </ul>
+          </div>
+
+          <div class="card">
+            <h3 id="phase-c">Phase C — <strong>1 July – 31 October 2026</strong></h3>
+            <ul>
+              <li>
+                <strong>OAuth2/OIDC or mTLS</strong> only if product requires user-facing or enterprise access patterns.
+              </li>
+              <li>
+                <strong>RFC 7807</strong> or compatible layer if SDK partners require
+                <code>application/problem+json</code>.
+              </li>
+              <li>
+                <strong>Developer portal</strong> expansion beyond Swagger UI: guides, quickstarts, status page links (see
+                <a href="#7-beyond-baseline-how-top-companies-treat-openapi-and-swagger">Beyond baseline</a>).
+              </li>
+            </ul>
+          </div>
+
+          <p>
+            <strong>Risks:</strong> Distributed limits and OAuth need infra and security review; conditional GETs, ETag, and
+            idempotency key normalization are mostly application work once product scope is clear.
+          </p>
+        </section>
+
+        <section>
+          <h2 id="7-beyond-baseline-how-top-companies-treat-openapi-and-swagger">
+            7. Beyond baseline: how top companies treat OpenAPI and “Swagger”
+          </h2>
+          <p>
+            Baseline practices (request IDs, idempotency, structured errors) are expected from any serious API.
+            <strong>Large API-first companies</strong> (e.g. Stripe, Twilio, OpenAI, GitHub, major cloud providers)
+            typically
+            invest <strong>2–3 levels deeper</strong>: they treat the <strong>spec and runtime as the source of
+            truth</strong>,
+            and they treat <strong>documentation as a product</strong> (DX), backed by governance and automation.
+          </p>
+
+          <h3 id="7-1-swagger-not-whole-story">7.1 “Swagger UI” is rarely the whole story</h3>
+          <p>Many teams expose default Swagger UI at <code>/docs</code> and stop. Strong teams usually:</p>
+          <ul>
+            <li>
+              Ship a <strong>developer portal</strong> (custom or generator-based) where OpenAPI is
+              <strong>one backend artifact</strong>, not the only UX.
+            </li>
+            <li>
+              Separate <strong>Reference</strong> (machine-generated from OpenAPI) from
+              <strong>Guides / Quickstarts / Tutorials</strong> (human-authored, scenario-based).
+            </li>
+          </ul>
+
+          <h3 id="7-2-premium-patterns">7.2 Common “premium” documentation patterns (2024–2026)</h3>
+          <div style="overflow-x: auto">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Pattern</th>
+                  <th scope="col">Why it matters</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><strong>Three-column layout</strong> (nav | prose + schema | code samples)</td>
+                  <td>
+                    Developers scan code first; used by Stripe-like experiences and tools like Redocly, Stoplight Elements,
+                    Scalar, Bump.sh.
+                  </td>
+                </tr>
+                <tr>
+                  <td><strong>Pre-filled examples</strong></td>
+                  <td>Authenticated users see <strong>their</strong> API keys / project ids in snippets (reduces copy-paste
+                    errors).</td>
+                  </tr>
+                  <tr>
+                    <td><strong>Multi-language snippets</strong></td>
+                    <td>curl + several SDKs from the same underlying spec or templates.</td>
+                  </tr>
+                  <tr>
+                    <td><strong>Search + (optional) AI</strong></td>
+                    <td>Semantic search across guides + reference, not only endpoint titles.</td>
+                  </tr>
+                  <tr>
+                    <td><strong>Tested snippets</strong></td>
+                    <td>Examples extracted from repos and executed in CI (documentation-as-tests).</td>
+                  </tr>
+                  <tr>
+                    <td><strong>Error catalog</strong></td>
+                    <td>Dedicated pages per error code (Twilio-style) beyond inline schema descriptions.</td>
+                  </tr>
+                  <tr>
+                    <td><strong>Public OpenAPI repos</strong></td>
+                    <td>e.g. Stripe <code>stripe/openapi</code> — <code>latest</code> vs <code>preview</code>, JSON/YAML,
+                      SDK-oriented variants.</td>
+                    </tr>
+                    <tr>
+                      <td><strong>Machine discovery</strong></td>
+                      <td>Some ecosystems expose <code>GET /.well-known/openapi.json</code> or a stable URL for integrators and
+                        tools.</td>
+                      </tr>
+                      <tr>
+                        <td><strong>Overlays</strong></td>
+                        <td>OpenAPI overlays adjust branding/navigation <strong>without</strong> forking the canonical spec.</td>
+                      </tr>
+                      <tr>
+                        <td><strong>Governance linting</strong></td>
+                        <td>Spectral, Redocly CLI, Vacuum — style rules in CI block merges (naming, pagination, security, errors).
+                        </td>
+                      </tr>
+                      <tr>
+                        <td><strong>AsyncAPI</strong></td>
+                        <td>For event streams / webhooks, parallel to REST OpenAPI (used where event contracts matter).</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+
+                <h3 id="7-3-company-snapshots">7.3 Company snapshots (illustrative, not exhaustive)</h3>
+                <ul>
+                  <li>
+                    <strong>Stripe:</strong> Custom docs site; interactive request builder; public OpenAPI monorepo; idempotency
+                    as
+                    a first-class contract; heavy investment in SDKs and versioning.
+                  </li>
+                  <li>
+                    <strong>Twilio:</strong> Modular OpenAPI files; strong quickstarts; rich error reference; SDK generation from
+                    specs.
+                  </li>
+                  <li>
+                    <strong>OpenAI / GitHub / AWS:</strong> Combine narrative guides with reference; versioning and
+                    breaking-change
+                    communication; operational headers documented (rate limits, request IDs).
+                  </li>
+                </ul>
+
+                <h3 id="7-4-governance-stack">7.4 “API governance” stack (what top teams automate)</h3>
+                <ol>
+                  <li><strong>Single source of truth</strong> — OpenAPI drives docs, mocks, tests, and often SDKs.</li>
+                  <li>
+                    <strong>CI rules</strong> — Spectral (or similar) with custom rulesets aligned to internal style guides
+                    (inspired by Google AIP, Microsoft REST guidelines, etc.).
+                  </li>
+                  <li><strong>Changelog discipline</strong> — Deprecation dates, sunset, migration notes.</li>
+                  <li>
+                    <strong>Observability in docs</strong> — Document <code>X-Request-Id</code>, rate limit headers, retry
+                    guidance,
+                    and (when applicable) tracing headers.
+                  </li>
+                </ol>
+
+                <h3 id="7-5-trade-offs">7.5 Trade-offs</h3>
+                <ul>
+                  <li>
+                    <strong>Monolithic OpenAPI</strong> (e.g. one large file): easier for SDK generation; harder to review in Git.
+                  </li>
+                  <li>
+                    <strong>Modular specs</strong> (many files): easier ownership per team; need orchestration for consumers.
+                  </li>
+                </ul>
+                <p>
+                  Study App is <strong>not</strong> at Stripe-scale portal spend — that is expected. The value is
+                  <strong>selective adoption</strong>: e.g. Spectral in CI + Redoc + published spec + guides can reach
+                  <strong>top-decile</strong> quality without a custom frontend.
+                </p>
+              </section>
+
+              <section>
+                <h2 id="document-history">8. Document history</h2>
+                <div style="overflow-x: auto">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th scope="col">Date</th>
+                        <th scope="col">Change</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>2026-04-14</td>
+                        <td>Initial REST API assessment (HTML).</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <p><em>End of document.</em></p>
+              </section>
+            </main>
+          </body>
+
+        </html>

--- a/docs/audit/2026-04-14-documentation-experience-assessment.html
+++ b/docs/audit/2026-04-14-documentation-experience-assessment.html
@@ -1,0 +1,779 @@
+<!doctype html>
+<html lang="en">
+
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Documentation Experience (DX) Assessment — Study App (14 Apr 2026)</title>
+    <link rel="stylesheet" href="../assets/docs.css" />
+    <script defer src="../assets/docs-nav.js"></script>
+  </head>
+
+  <body>
+    <main class="container">
+      <h1>Documentation Experience (DX) Assessment — Study App</h1>
+      <div id="docs-top-nav"></div>
+      <p class="lead">
+        <strong>Assessment date:</strong> 14 April 2026<br />
+        <strong>Stack:</strong> Static HTML under <code>docs/</code>, shared CSS, automated doc sync (see
+        <a href="../developer/0008-docs-pipeline.html">docs pipeline</a>)<br />
+        <strong>Scope:</strong> Documentation Experience (DX) for this repository — how readers find, understand, trust,
+        and
+        act on technical documentation (guides, ADRs, generated API reference, runbooks).<br />
+        <strong>Document purpose:</strong> Map industry reference practices to Study App’s current posture, score maturity
+        (Table&nbsp;2), prioritize gaps, and record a mitigation path plus checklist.
+      </p>
+
+      <section>
+        <h2 id="table-of-contents">Table of contents</h2>
+        <ol>
+          <li><a href="#1-scope-and-methodology">Scope and methodology</a></li>
+          <li><a href="#table-1-reference-practices">Table 1 — Reference practices</a></li>
+          <li><a href="#table-2-study-app-scores">Table 2 — Study App mapping and scores</a></li>
+          <li><a href="#4-scoring-summary">Scoring summary</a></li>
+          <li><a href="#5-gaps-refactors-and-recommendations">Gaps, refactors, and recommendations</a></li>
+          <li><a href="#6-mitigation-plan-and-indicative-deadlines">Mitigation plan and indicative deadlines</a></li>
+          <li><a href="#8-document-history">Document history</a></li>
+        </ol>
+      </section>
+
+      <section>
+        <h2 id="1-scope-and-methodology">1. Scope and methodology</h2>
+
+        <h3 id="1-1-scope">1.1 Scope</h3>
+        <p>
+          <strong>Documentation Experience (DX)</strong> here means the end-to-end experience of consuming technical
+          documentation: navigation, search, examples, API reference, operational runbooks, and trust signals (changelog,
+          errors). This assessment is <strong>stack-agnostic</strong> in Table&nbsp;1; Table&nbsp;2 is specific to Study
+          App’s published <code>docs/</code> tree and automation.
+        </p>
+        <p>
+          The review targets a <strong>PET-scale</strong> service: a documentation site and repo workflows, not a
+          full commercial developer portal with billing and org management unless Table&nbsp;1 rows explicitly call for
+          that pattern.
+        </p>
+
+        <h3 id="1-2-method">1.2 Method</h3>
+        <p>The review proceeds in four steps:</p>
+        <ol>
+          <li>
+            <strong>Reference catalogue</strong> — Table&nbsp;1 lists DX practices with neutral descriptions (what “good”
+            usually means). Rows <strong>17–18</strong> are grouped under “A11y / i18n*” (accessibility and
+            internationalization).
+          </li>
+          <li>
+            <strong>Implementation mapping</strong> — Table&nbsp;2 scores each practice (1–10) against the
+            <strong>current</strong> repository, with evidence pointers (paths, ADRs, tooling).
+          </li>
+          <li>
+            <strong>Synthesis</strong> — overall score, gaps grouped by priority (<a
+            href="#5-gaps-refactors-and-recommendations">section 5</a>), and a mitigation timeline (<a
+            href="#6-mitigation-plan-and-indicative-deadlines">section 6</a>).
+          </li>
+          <li>
+            <strong>Follow-ups</strong> — actionable checklist (<a href="#7-actionable-checklist-top-decile-dx">section
+            7</a>) and document history (<a href="#8-document-history">section 8</a>).
+          </li>
+        </ol>
+        <p>
+          Scores are <strong>subjective</strong> and indicative; they are not a WCAG certification, formal user study, or
+          performance review of individuals.
+        </p>
+
+        <h3 id="1-3-what-was-examined">1.3 What was examined</h3>
+        <ul>
+          <li>
+            Site structure: <code>docs/index.html</code>, ADRs under <code>docs/adr/</code>, developer guides under
+            <code>docs/developer/</code>, runbooks under <code>docs/runbooks/</code>.
+          </li>
+          <li>
+            Generated surfaces: OpenAPI baseline and explorer patterns, pdoc API HTML, UML and related automation
+            described
+            in engineering docs.
+          </li>
+          <li>
+            Quality gates: <code>make docs-check</code>, changelog policy, OpenAPI governance references in ADRs.
+          </li>
+        </ul>
+
+        <h3 id="1-4-what-this-assessment-is-not">1.4 What this assessment is not</h3>
+        <ul>
+          <li>It is not a full WCAG 2.2 AA audit of every HTML template.</li>
+          <li>It does not replace usability testing with real integrators or support transcript analysis.</li>
+          <li>It does not certify localization, analytics, or AI assistants — only notes typical gaps if absent.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 id="table-1-reference-practices">2. Table: Reference practices (Documentation Experience)</h2>
+        <p>
+          <strong>Category</strong> groups the theme; <strong>Practice</strong> is a concise name;
+          <strong>Description</strong> states expected behaviour; <strong>Typical benchmark</strong> notes who often
+          exemplifies it (patterns vary by company size).
+          <br>*A11y / i18n:</strong> Accessibility and internationalization (rows 17–18).
+          <div style="overflow-x: auto">
+            <table class="audit-ref-table">
+              <thead>
+                <tr>
+                  <th scope="col">#</th>
+                  <th scope="col">Category</th>
+                  <th scope="col">Practice</th>
+                  <th scope="col">Reference description</th>
+                  <th scope="col">Typical benchmark</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>1</td>
+                  <td>IA</td>
+                  <td><a href="https://diataxis.fr/">Diátaxis-style split</a></td>
+                  <td>
+                    Separate <strong>tutorials</strong> (learning-oriented), <strong>how-to guides</strong>
+                    (task-oriented), <strong>reference</strong> (information-oriented), and <strong>explanation</strong>
+                    (understanding-oriented). Users land in the right mode for their goal; navigation labels reflect it.
+                  </td>
+                  <td>Canonical mental model for technical docs; adopted widely in API and platform teams.</td>
+                </tr>
+                <tr>
+                  <td>2</td>
+                  <td>IA</td>
+                  <td>Progressive disclosure</td>
+                  <td>
+                    “Happy path” first; edge cases, limits, and failure modes linked or collapsed so beginners are not
+                    overwhelmed; experts can jump to reference or deep links.
+                  </td>
+                  <td>Reduces time-to-first-success (TTFS) without hiding rigor.</td>
+                </tr>
+                <tr>
+                  <td>3</td>
+                  <td>Journey</td>
+                  <td>Onboarding spine</td>
+                  <td>
+                    A single curated path: install → authenticate → first API call / first deploy → next steps. Each step
+                    has verification (“you should see…”) and links to troubleshooting.
+                  </td>
+                  <td>Stripe/Twilio-style quickstarts remain the pattern to beat for APIs.</td>
+                </tr>
+                <tr>
+                  <td>4</td>
+                  <td>Ops</td>
+                  <td>Docs-as-code</td>
+                  <td>
+                    Docs live in version control; changes are reviewed like code; publishing is automated. Prose and
+                    diagrams
+                    are diffable; ownership is explicit (CODEOWNERS or equivalent).
+                  </td>
+                  <td>Baseline for mature engineering orgs; see also ADR-driven governance.</td>
+                </tr>
+                <tr>
+                  <td>5</td>
+                  <td>Ops</td>
+                  <td>Single source of truth (SSOT)</td>
+                  <td>
+                    Generated sections (OpenAPI, CLI help, config tables, route lists) are produced from artifacts, not
+                    hand-copied. Manual text links to generated anchors explicitly.
+                  </td>
+                  <td>Eliminates the #1 DX failure: docs that contradict production.</td>
+                </tr>
+                <tr>
+                  <td>6</td>
+                  <td>Ops</td>
+                  <td>Versioning aligned with product</td>
+                  <td>
+                    Doc sets are versioned (or time-versioned) with the product; deprecation and sunset are visible in-docs
+                    and in machine-readable metadata where applicable.
+                  </td>
+                  <td>Essential once you have more than one supported major version.</td>
+                </tr>
+                <tr>
+                  <td>7</td>
+                  <td>Quality</td>
+                  <td>CI for docs</td>
+                  <td>
+                    Pipeline runs link checking, spelling/grammar linters (e.g. Vale with a house style), OpenAPI/MDX
+                    validators, and (for APIs) contract tests. Broken links fail the build or warn with SLAs.
+                  </td>
+                  <td>“Treat docs like code” in the strict sense — measurable gates.</td>
+                </tr>
+                <tr>
+                  <td>8</td>
+                  <td>Quality</td>
+                  <td>Tested code paths</td>
+                  <td>
+                    Copy-paste examples are executed in CI (or marked as pseudo-code). CLI snippets and curl examples target
+                    real endpoints; responses shown match schema or are clearly illustrative.
+                  </td>
+                  <td>Top teams refuse “example rot.”</td>
+                </tr>
+                <tr>
+                  <td>9</td>
+                  <td>Quality</td>
+                  <td>Error and failure documentation</td>
+                  <td>
+                    Errors are documented systematically: HTTP status, stable machine-readable codes where applicable,
+                    remediation, idempotency implications, and links to runbooks.
+                  </td>
+                  <td>Pairs with OpenAPI <code>Problem Details</code> / structured error bodies.</td>
+                </tr>
+                <tr>
+                  <td>10</td>
+                  <td>API docs</td>
+                  <td>OpenAPI (or equivalent) as contract</td>
+                  <td>
+                    Reference is generated from the spec; examples are first-class; auth schemes and security requirements
+                    are explicit; servers and environments are listed without ambiguity.
+                  </td>
+                  <td>Industry default for HTTP APIs; governance lint (Spectral/Redocly) is common.</td>
+                </tr>
+                <tr>
+                  <td>11</td>
+                  <td>API docs</td>
+                  <td>Interactive “try it”</td>
+                  <td>
+                    Sandboxed requests against test credentials, or clear warnings for production. Rate limits and scopes
+                    are
+                    visible before the user sends a request.
+                  </td>
+                  <td>Improves learning; must be safe-by-default.</td>
+                </tr>
+                <tr>
+                  <td>12</td>
+                  <td>SDK docs</td>
+                  <td>Multi-surface examples</td>
+                  <td>
+                    Same conceptual page offers language tabs (curl + official SDKs); idioms match each language; versioning
+                    notes per SDK where releases diverge.
+                  </td>
+                  <td>Expected at platform scale; smaller teams may start with one SDK + HTTP.</td>
+                </tr>
+                <tr>
+                  <td>13</td>
+                  <td>Discovery</td>
+                  <td>First-class search</td>
+                  <td>
+                    Full-text search with typo tolerance; results ranked by recency/relevance; scoped search within a doc
+                    set
+                    (e.g. “API reference only”). Offline/static options (Pagefind, Lunr) remain valid.
+                  </td>
+                  <td>Algolia DocSearch and similar patterns are table stakes for large sites.</td>
+                </tr>
+                <tr>
+                  <td>14</td>
+                  <td>Discovery</td>
+                  <td>AI-assisted answers (2024–2026)</td>
+                  <td>
+                    Optional assistant grounded in <em>your</em> docs (RAG), with citations to source pages; guardrails for
+                    “I don’t know”; no training on customer secrets; logging aligned with privacy policy.
+                  </td>
+                  <td>Rapidly becoming expected; quality depends on chunking and retrieval, not model size alone.</td>
+                </tr>
+                <tr>
+                  <td>15</td>
+                  <td>UX</td>
+                  <td>Performance (Core Web Vitals)</td>
+                  <td>
+                    Doc sites load fast on mobile: optimize LCP (hero text, fonts), avoid huge client bundles on content
+                    pages, lazy-load non-critical widgets.
+                  </td>
+                  <td>DX is part of perceived product quality.</td>
+                </tr>
+                <tr>
+                  <td>16</td>
+                  <td>UX</td>
+                  <td>Deep links and anchors</td>
+                  <td>
+                    Stable URLs for sections; headings get permalink anchors; “copy link” affordances. API objects link to
+                    changelog entries when behaviour changes.
+                  </td>
+                  <td>Supports support tickets and Slack threads.</td>
+                </tr>
+                <tr>
+                  <td>17</td>
+                  <td>A11y / i18n*</td>
+                  <td>WCAG-aligned UI</td>
+                  <td>
+                    Semantic HTML, keyboard navigation, focus order, color contrast, captions/transcripts for video,
+                    descriptive link text (not “click here”).
+                  </td>
+                  <td>WCAG 2.2 AA is a common corporate bar for customer-facing docs.</td>
+                </tr>
+                <tr>
+                  <td>18</td>
+                  <td>A11y / i18n*</td>
+                  <td>Localization strategy</td>
+                  <td>
+                    If multilingual: translation workflow, glossary, and “source of truth” language; RTL and string
+                    expansion
+                    considered. If English-only: stated explicitly to set expectations.
+                  </td>
+                  <td>Enterprise buyers often require localized docs.</td>
+                </tr>
+                <tr>
+                  <td>19</td>
+                  <td>Inclusivity</td>
+                  <td>Plain, inclusive language</td>
+                  <td>
+                    Style guide for inclusive terms; avoid unnecessary idioms; define acronyms on first use; consistent
+                    terminology (controlled vocabulary).
+                  </td>
+                  <td>Reduces misreads for non-native speakers and new hires.</td>
+                </tr>
+                <tr>
+                  <td>20</td>
+                  <td>Trust</td>
+                  <td>Changelog discipline</td>
+                  <td>
+                    Human-readable changelog or release notes linked from docs; breaking changes are called out with
+                    migration steps; dates and version tags are unambiguous.
+                  </td>
+                  <td>Pairs with API versioning and ADR records for rationale.</td>
+                </tr>
+                <tr>
+                  <td>21</td>
+                  <td>Trust</td>
+                  <td>Security hygiene in examples</td>
+                  <td>
+                    No real secrets in repos; placeholders and env var names are standard; “redacted” samples for tokens;
+                    guidance on rotating leaked keys.
+                  </td>
+                  <td>Prevents docs from becoming an attack surface.</td>
+                </tr>
+                <tr>
+                  <td>22</td>
+                  <td>Feedback</td>
+                  <td>Visible feedback channel</td>
+                  <td>
+                    “Edit this page” (for open repos), issue templates, or thumbs up/down with optional comment. Feedback
+                    routes to owners; SLAs are realistic.
+                  </td>
+                  <td>Closes the loop between readers and authors.</td>
+                </tr>
+                <tr>
+                  <td>23</td>
+                  <td>Feedback</td>
+                  <td>Privacy-respecting analytics</td>
+                  <td>
+                    Aggregate navigation and search success metrics; minimize PII; document cookies/consent if required;
+                    distinguish docs traffic from app traffic.
+                  </td>
+                  <td>GDPR/CCPA-conscious teams prefer first-party or aggregated analytics.</td>
+                </tr>
+                <tr>
+                  <td>24</td>
+                  <td>Support</td>
+                  <td>Runbooks and on-call alignment</td>
+                  <td>
+                    Operational docs (incident response, dashboards, rollback) are kept next to developer docs or clearly
+                    cross-linked; ownership matches pager rotations.
+                  </td>
+                  <td>Blurs “product docs” vs “internal ops” — both are DX for different audiences.</td>
+                </tr>
+                <tr>
+                  <td>25</td>
+                  <td>Platform</td>
+                  <td>Developer portal pattern</td>
+                  <td>
+                    Single entry: identity/keys, usage dashboards, quotas, docs, and support — coherent navigation and
+                    branding. For smaller products, a minimal portal is “good README + API reference + status page.”
+                  </td>
+                  <td>At scale, portals integrate billing and org management; don’t over-build early.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section>
+          <h2 id="table-2-study-app-scores">3. Table: Study App mapping and indicative scores</h2>
+          <p>
+            One row per practice in Table&nbsp;1 (rows <strong>1–25</strong>): no bundled rows. Scores are
+            <strong>1–10</strong> indicative maturity (not a formal audit). Colour bands for the Score column are defined in
+            <code>docs/assets/docs.css</code> (see
+            <a href="../adr/0024-architecture-and-quality-assessment-documents.html#assessment-score-scale">ADR 0024</a>).
+          </p>
+          <div class="audit-score-legend-include" data-legend-id="dx"></div>
+          <noscript>
+            <p class="audit-score-legend-noscript">
+              Legend text lives in <code>docs/assets/audit-score-legend-fragment.html</code> (loaded by
+              <code>docs-nav.js</code> when JavaScript is on). See
+              <a href="../adr/0024-architecture-and-quality-assessment-documents.html#assessment-score-scale">ADR 0024</a>
+              for
+              the scale.
+            </p>
+          </noscript>
+          <div style="overflow-x: auto">
+            <table class="audit-score-table">
+              <thead>
+                <tr>
+                  <th scope="col">#</th>
+                  <th scope="col">Practice (Table&nbsp;1)</th>
+                  <th scope="col">Study App evidence / notes</th>
+                  <th scope="col">Score</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>1</td>
+                  <td>Diátaxis-style split</td>
+                  <td>
+                    Content is split across ADRs, developer guides, runbooks, and generated API reference, but landing pages
+                    do not consistently label pieces as tutorial vs how-to vs reference vs explanation. Readers infer
+                    structure
+                    from folders and titles.
+                  </td>
+                  <td class="score-good">7</td>
+                </tr>
+                <tr>
+                  <td>2</td>
+                  <td>Progressive disclosure</td>
+                  <td>
+                    Long-form guides and Makefile-oriented docs exist; happy path vs edge case is mostly a matter of author
+                    style, not a uniform pattern of “basics first, deep links for limits.”
+                  </td>
+                  <td class="score-good">7</td>
+                </tr>
+                <tr>
+                  <td>3</td>
+                  <td>Onboarding spine</td>
+                  <td>
+                    Developer guides cover local dev, workflows, and API topics; there is no single named page that chains
+                    install → authenticate → first successful request with explicit verification checkpoints end-to-end.
+                  </td>
+                  <td class="score-good">7</td>
+                </tr>
+                <tr>
+                  <td>4</td>
+                  <td>Docs-as-code</td>
+                  <td>
+                    <a href="../adr/0001-docs-as-code.html">ADR 0001</a>; HTML and assets live in git; changes are
+                    reviewable
+                    like code; <a href="../developer/0008-docs-pipeline.html">docs pipeline</a> automates sync and
+                    generation
+                    steps.
+                  </td>
+                  <td class="score-excellent">9</td>
+                </tr>
+                <tr>
+                  <td>5</td>
+                  <td>Single source of truth (SSOT)</td>
+                  <td>
+                    OpenAPI baseline and governance reduce drift vs hand-maintained reference; pdoc reflects the Python API;
+                    UML and markers are generated or checked. Narrative docs still require manual care to stay aligned with
+                    env tables and behaviour.
+                  </td>
+                  <td class="score-excellent">9</td>
+                </tr>
+                <tr>
+                  <td>6</td>
+                  <td>Versioning aligned with product</td>
+                  <td>
+                    <code>CHANGELOG.md</code> with a CI changelog gate; ADRs record decisions. Doc sets are not published as
+                    separate versioned subsites; alignment is via repo tags and changelog entries rather than per-major doc
+                    trees.
+                  </td>
+                  <td class="score-good">8</td>
+                </tr>
+                <tr>
+                  <td>7</td>
+                  <td>CI for docs</td>
+                  <td>
+                    <code>make docs-check</code> fails on drift between generated and committed artifacts; OpenAPI checks
+                    run
+                    in the main quality pipeline. Spelling or Vale-style prose lint for all hand-written HTML is not assumed
+                    everywhere.
+                  </td>
+                  <td class="score-good">8</td>
+                </tr>
+                <tr>
+                  <td>8</td>
+                  <td>Tested code paths</td>
+                  <td>
+                    Contract and API tests exercise the runtime; copy-paste examples in prose docs are not systematically
+                    executed as part of a docs-specific CI job. Some examples are illustrative only.
+                  </td>
+                  <td class="score-needs-attention">6</td>
+                </tr>
+                <tr>
+                  <td>9</td>
+                  <td>Error and failure documentation</td>
+                  <td>
+                    Error matrix and OpenAPI examples document stable codes; runbooks cover operational angles. Not a single
+                    Twilio-style public “error catalog” site, but the material exists across docs and spec.
+                  </td>
+                  <td class="score-good">8</td>
+                </tr>
+                <tr>
+                  <td>10</td>
+                  <td>OpenAPI (or equivalent) as contract</td>
+                  <td>
+                    Governance ADRs, <code>docs/openapi/openapi-baseline.json</code>, embedded explorer patterns; reference
+                    is driven from the app’s OpenAPI rather than hand-written endpoint lists alone.
+                  </td>
+                  <td class="score-excellent">9</td>
+                </tr>
+                <tr>
+                  <td>11</td>
+                  <td>Interactive “try it”</td>
+                  <td>
+                    Swagger UI at <code>/docs</code> and static <code>docs/openapi-explorer.html</code> against the
+                    committed
+                    snapshot; users must supply their own keys and understand environment risk. Rate limits and auth are
+                    documented in OpenAPI and prose.
+                  </td>
+                  <td class="score-good">8</td>
+                </tr>
+                <tr>
+                  <td>12</td>
+                  <td>Multi-surface examples</td>
+                  <td>
+                    Primary examples are HTTP-oriented (curl, OpenAPI); there is no tabbed curl + multiple official SDKs on
+                    the same page. Scope matches a small service without generated client libraries.
+                  </td>
+                  <td class="score-needs-attention">5</td>
+                </tr>
+                <tr>
+                  <td>13</td>
+                  <td>First-class search</td>
+                  <td>
+                    Generated API docs include client-side search (e.g. pdoc search). There is no dedicated full-site search
+                    across all HTML guides and ADRs comparable to Algolia DocSearch unless added separately (e.g. Pagefind).
+                  </td>
+                  <td class="score-needs-attention">5</td>
+                </tr>
+                <tr>
+                  <td>14</td>
+                  <td>AI-assisted answers (2024–2026)</td>
+                  <td>
+                    No in-product docs assistant or RAG over this doc set is part of the repository. Optional future work;
+                    must be citation-grounded if introduced.
+                  </td>
+                  <td class="score-needs-attention">4</td>
+                </tr>
+                <tr>
+                  <td>15</td>
+                  <td>Performance (Core Web Vitals)</td>
+                  <td>
+                    Static HTML and shared CSS; no heavy SPA framework on doc pages. Performance depends on hosting and
+                    asset
+                    weight; not formally audited against Core Web Vitals in this assessment.
+                  </td>
+                  <td class="score-good">7</td>
+                </tr>
+                <tr>
+                  <td>16</td>
+                  <td>Deep links and anchors</td>
+                  <td>
+                    HTML pages use stable paths under <code>docs/</code>; shared nav and section anchors support linking to
+                    sections. Not every page exposes a visible “copy link to heading” control.
+                  </td>
+                  <td class="score-good">7</td>
+                </tr>
+                <tr>
+                  <td>17</td>
+                  <td>WCAG-aligned UI</td>
+                  <td>
+                    Semantic HTML patterns and shared stylesheet; no claim of a full WCAG 2.2 AA audit of every template in
+                    this mapping.
+                  </td>
+                  <td class="score-needs-attention">6</td>
+                </tr>
+                <tr>
+                  <td>18</td>
+                  <td>Localization strategy</td>
+                  <td>
+                    Documentation is English-first; multilingual translation workflow and glossary are out of scope unless
+                    the product adds them explicitly.
+                  </td>
+                  <td class="score-needs-attention">5</td>
+                </tr>
+                <tr>
+                  <td>19</td>
+                  <td>Plain, inclusive language</td>
+                  <td>
+                    Engineering and ADR tone is generally precise; a standalone inclusive-language style guide for all prose
+                    is not asserted here.
+                  </td>
+                  <td class="score-good">7</td>
+                </tr>
+                <tr>
+                  <td>20</td>
+                  <td>Changelog discipline</td>
+                  <td>
+                    Keep a Changelog format; CI gate on main/master pushes and PRs; ties release communication to repo
+                    history.
+                  </td>
+                  <td class="score-excellent">9</td>
+                </tr>
+                <tr>
+                  <td>21</td>
+                  <td>Security hygiene in examples</td>
+                  <td>
+                    Env templates and docs emphasize configuration; examples use placeholders for keys. Contributors are
+                    guided not to commit secrets; aligns with normal OSS practice.
+                  </td>
+                  <td class="score-good">8</td>
+                </tr>
+                <tr>
+                  <td>22</td>
+                  <td>Visible feedback channel</td>
+                  <td>
+                    Typical path is GitHub Issues / PR process for a repo-hosted doc set; no in-page “was this helpful?”
+                    widget is assumed.
+                  </td>
+                  <td class="score-needs-attention">6</td>
+                </tr>
+                <tr>
+                  <td>23</td>
+                  <td>Privacy-respecting analytics</td>
+                  <td>
+                    Static hosting implies no first-party docs analytics unless the team adds it; no cookie banner or
+                    analytics pipeline is described as part of this project’s default docs delivery.
+                  </td>
+                  <td class="score-needs-attention">5</td>
+                </tr>
+                <tr>
+                  <td>24</td>
+                  <td>Runbooks and on-call alignment</td>
+                  <td>
+                    Runbooks exist under <code>docs/runbooks/</code>; engineering practices and ADRs link operational and
+                    design context. On-call rotation is outside repo scope.
+                  </td>
+                  <td class="score-good">8</td>
+                </tr>
+                <tr>
+                  <td>25</td>
+                  <td>Developer portal pattern</td>
+                  <td>
+                    The repo delivers a documentation site (index, guides, API explorer, ADRs) rather than a full SaaS-style
+                    portal with billing, org dashboards, and integrated support. Appropriate for PET scale.
+                  </td>
+                  <td class="score-needs-attention">6</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+        </section>
+
+        <section>
+          <h2 id="4-scoring-summary">4. Scoring summary</h2>
+          <p>
+            <strong>Overall (subjective, PET-scale docs site):</strong> approximately <strong>8 / 10</strong> on the 1–10
+            scale.
+            <br />
+            <strong>To approach top decile:</strong> explicit Diátaxis labels, one golden onboarding path, full-site search,
+            prose lint and link checking in CI, and (optionally) citation-grounded AI — see
+            <a href="#5-gaps-refactors-and-recommendations">section 5</a>.
+          </p>
+        </section>
+
+        <section>
+          <h2 id="5-gaps-refactors-and-recommendations">5. Gaps, refactors, and recommendations</h2>
+          <p>
+            Grouped by implementation priority. Row numbers refer to
+            <a href="#table-1-reference-practices">Table 1</a> / <a href="#table-2-study-app-scores">Table 2</a>.
+          </p>
+
+          <h3 id="5-1-should-add">5.1 Should add</h3>
+          <p><em>High impact for moderate effort; closes visible gaps in Table&nbsp;2.</em></p>
+          <ol>
+            <li>
+              <strong>Explicit Diátaxis labels</strong> (row 1): e.g. tag or group pages as tutorial / how-to / reference /
+              explanation so readers self-select mode.
+            </li>
+            <li>
+              <strong>One golden onboarding page</strong> (row 3): install → authenticate → first successful request with
+              verification steps and troubleshooting links.
+            </li>
+            <li>
+              <strong>Site search</strong> (row 13): e.g. Pagefind or similar over static HTML if browse-only navigation
+              limits discovery as content grows.
+            </li>
+          </ol>
+
+          <h3 id="5-2-should-refactor">5.2 Should refactor / tighten</h3>
+          <p><em>Improve consistency without changing product scope.</em></p>
+          <ol>
+            <li>
+              <strong>Prose lint + link check in CI</strong> (row 7): extend beyond drift checks for generated artifacts
+              where
+              hand-written HTML remains.
+            </li>
+            <li>
+              <strong>Example execution policy</strong> (row 8): mark snippets as illustrative or run representative curls
+              in CI.
+            </li>
+            <li>
+              <strong>Deep-link affordances</strong> (row 16): optional “copy link to heading” on key guides where useful.
+            </li>
+          </ol>
+
+          <h3 id="5-3-nice-to-have">5.3 Nice-to-have (product-dependent)</h3>
+          <p><em>Optional enhancements once baseline DX is stable.</em></p>
+          <ol>
+            <li>
+              <strong>AI-assisted answers</strong> (row 14): only with retrieval over <em>this</em> doc set, citations, and
+              clear abstention; not a substitute for OpenAPI truth.
+            </li>
+            <li>
+              <strong>Privacy-respecting analytics</strong> (row 23): if traffic insight is needed, use first-party or
+              aggregate patterns and document consent implications.
+            </li>
+            <li>
+              <strong>Localization</strong> (row 18): if enterprise buyers require it, add translation workflow and
+              glossary;
+              otherwise keep English-first explicit.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h2 id="6-mitigation-plan-and-indicative-deadlines">6. Mitigation plan and indicative deadlines</h2>
+          <p>Dates are <strong>indicative</strong>; preserve ordering if timelines slip.</p>
+
+          <div class="card">
+            <h3 id="phase-a-dx">Phase A — by <strong>30 April 2026</strong></h3>
+            <ul>
+              <li>Add Diátaxis labels (or equivalent IA cues) on <code>docs/index.html</code> and section entry points.</li>
+              <li>
+                Publish one golden onboarding page linking local dev, first API call, and error/security references (rows 1,
+                3).
+              </li>
+            </ul>
+          </div>
+
+          <div class="card">
+            <h3 id="phase-b-dx">Phase B — by <strong>30 June 2026</strong></h3>
+            <ul>
+              <li>Introduce full-site search (e.g. Pagefind) or document why deferred (row 13).</li>
+              <li>Add prose lint and link checking for hand-maintained HTML paths in CI (row 7).</li>
+              <li>Revisit Table&nbsp;2 scores after changes; update this document’s history.</li>
+            </ul>
+          </div>
+        </section>
+      </section>
+
+      <section>
+        <h2 id="8-document-history">7. Document history</h2>
+        <div style="overflow-x: auto">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Date</th>
+                <th scope="col">Change</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>2026-04-14</td>
+                <td>Initial DX (Documentation Experience) reference assessment — HTML edition.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p><em>End of document.</em></p>
+      </section>
+    </main>
+  </body>
+
+</html>

--- a/docs/audit/README.html
+++ b/docs/audit/README.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Architecture &amp; quality assessments — index</title>
+    <link rel="stylesheet" href="../assets/docs.css" />
+    <script defer src="../assets/docs-nav.js"></script>
+  </head>
+
+  <body>
+    <main class="container">
+      <h1>Architecture &amp; quality assessments</h1>
+      <div id="docs-top-nav"></div>
+      <p class="lead">
+        Stand-alone <strong>maturity assessments</strong> for this repository: each report maps the Study App to a neutral
+        catalogue of reference practices (Table&nbsp;1), scores evidence and gaps (Table&nbsp;2), and records mitigations
+        and checklists. They complement ADRs (which capture <em>decisions</em>) with a dated snapshot of <em>how we
+        compare</em> to common industry expectations.
+      </p>
+
+      <div class="card">
+        <h2>Format and location</h2>
+        <p>
+          Files live under <code>docs/audit/</code> as static HTML, named
+          <code><var>YYYY-MM-DD</var>-<var>topic</var>-assessment.html</code>. Conventions, scoring bands, and the shared
+          Table&nbsp;2 legend are defined in
+          <a href="../adr/0024-architecture-and-quality-assessment-documents.html">ADR 0024</a>.
+        </p>
+      </div>
+
+      <div class="card">
+        <h2>All published assessments</h2>
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Assessment</th>
+              <th scope="col">Date</th>
+              <th scope="col">Focus</th>
+              <th scope="col">Open</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>REST API assessment</td>
+              <td>2026-04-14</td>
+              <td>HTTP API, OpenAPI governance, idempotency, security headers, observability hooks, CI contract checks.</td>
+              <td><a href="./2026-04-14-api-assessment.html">Open</a></td>
+            </tr>
+            <tr>
+              <td>Documentation Experience (DX) assessment</td>
+              <td>2026-04-14</td>
+              <td>Information architecture, docs-as-code, discovery, API docs UX, accessibility, feedback, and related DX
+                themes.</td>
+                <td><a href="./2026-04-14-documentation-experience-assessment.html">Open</a></td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            New assessments should be listed here when added. Changes to this index or to assessment files are worth noting
+            in <a href="../CHANGELOG.md">docs/CHANGELOG.md</a>.
+          </p>
+        </div>
+      </main>
+    </body>
+
+  </html>

--- a/docs/backlog/README.html
+++ b/docs/backlog/README.html
@@ -23,6 +23,10 @@
         href="../adr/0018-adr-lifecycle-ratification-and-badges.html">ADR
         0018</a>).
     </p>
+    <p class="backlog-intro">
+      <strong>See also:</strong> <a href="../audit/README.html">Architecture &amp; quality assessments</a> (indexed
+      maturity reports under <code>docs/audit/</code>, <a href="../adr/0024-architecture-and-quality-assessment-documents.html">ADR 0024</a>).
+    </p>
 
     <section class="card" aria-labelledby="legend-title">
       <h2 id="legend-title">Status legend</h2>

--- a/docs/developer/README.html
+++ b/docs/developer/README.html
@@ -119,6 +119,11 @@
                             <td>Prefixes for branch names, <code>main</code> as trunk, tags, hotfixes.</td>
                             <td><a href="../adr/0017-branch-naming-and-repository-workflow.html">Open ADR 0017</a></td>
                           </tr>
+                          <tr>
+                            <td>Architecture &amp; quality assessments</td>
+                            <td>Maturity snapshots vs reference practices (API, DX, …); format in <a href="../adr/0024-architecture-and-quality-assessment-documents.html">ADR 0024</a>.</td>
+                            <td><a href="../audit/README.html">Open audit index</a></td>
+                          </tr>
                         </tbody>
                       </table>
                     </div>

--- a/docs/engineering-practices.html
+++ b/docs/engineering-practices.html
@@ -18,6 +18,15 @@
         and operational runbook discipline.
       </p>
 
+      <div class="card">
+        <h2 id="architecture-quality-assessments">Architecture &amp; quality assessments</h2>
+        <p>
+          Periodic audit-style reports (API, documentation experience, …) live under <code>docs/audit/</code> with a
+          shared format described in <a href="./adr/0024-architecture-and-quality-assessment-documents.html">ADR 0024</a>.
+          <a href="./audit/README.html">Browse all assessment reports</a>.
+        </p>
+      </div>
+
       <section>
         <h2 id="dev-guide">1. Development Guide</h2>
         <div class="card">

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,6 +34,18 @@
       </div>
 
       <div class="card">
+        <h2>Architecture &amp; quality assessments</h2>
+        <p>
+          Periodic maturity snapshots versus industry reference practices (scored tables, gaps, mitigations). Not a
+          substitute for ADRs — see <a href="./adr/0024-architecture-and-quality-assessment-documents.html">ADR 0024</a>.
+        </p>
+        <p>
+          <strong><a href="./audit/README.html">Browse all assessment reports</a></strong> — REST API, Documentation
+          Experience, and future audits indexed in one place.
+        </p>
+      </div>
+
+      <div class="card">
         <h2>Start here</h2>
         <table>
           <thead>
@@ -62,6 +74,10 @@
             <tr>
               <td>ADRs</td>
               <td><a href="./adr/README.html">adr/README.html</a></td>
+            </tr>
+            <tr>
+              <td>Architecture &amp; quality assessments (audits)</td>
+              <td><a href="./audit/README.html">audit/README.html</a></td>
             </tr>
             <tr>
               <td>Runbooks</td>

--- a/docs/runbooks/README.html
+++ b/docs/runbooks/README.html
@@ -21,6 +21,10 @@
           This page is an entry point for operational procedures. Use the table to quickly open the needed runbook,
           identify the incident type, and follow the standardized recovery checklist.
         </p>
+        <p>
+          <strong>Related:</strong> architecture and quality <a href="../audit/README.html">maturity assessments</a>
+          (separate from runbooks — dated snapshots vs reference practices per <a href="../adr/0024-architecture-and-quality-assessment-documents.html">ADR 0024</a>).
+        </p>
         <table>
           <thead>
             <tr>

--- a/docs/system-analysis.html
+++ b/docs/system-analysis.html
@@ -18,6 +18,14 @@
         API contracts, and ADR references.
       </p>
 
+      <div class="card">
+        <h2>Architecture &amp; quality assessments</h2>
+        <p>
+          For dated maturity reviews (reference practices, scores, gaps), see the
+          <a href="./audit/README.html">assessment reports index</a> (<a href="./adr/0024-architecture-and-quality-assessment-documents.html">ADR 0024</a>).
+        </p>
+      </div>
+
       <section>
         <h2>1. Problem Statement</h2>
         <div class="card">


### PR DESCRIPTION
- Add ADR 0024 and static HTML assessments under docs/audit/ (API, DX) with shared score legend fragment and CSS bands.

- Add docs/audit/README.html (English index); link from docs/index, README, developer/ADR hubs, engineering-practices, system-analysis, runbooks, backlog.

- Top nav: Assessments entry; highlight audit/* paths in docs-nav.js.

- Record changes in root and docs CHANGELOG.md.

- Remove unused rel_posix in format_docs_html.py (ruff F841).

Made-with: Cursor