### PR TITLE
Docs/docs polish

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the **documentation tree** under `docs/` (and related doc
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 2026-04-18
+
+### Added
+
+- **Dark theme** for hand-written documentation: [`docs/assets/docs-theme.css`](assets/docs-theme.css) (palette + overrides), loaded after [`docs/assets/docs.css`](assets/docs.css) on all pages that already linked `docs.css`.
+- **Theme control** in [`docs/assets/docs-nav.js`](assets/docs-nav.js): cycles **Auto** (follows `prefers-color-scheme`) → **Light** → **Dark** → Auto; preference stored in `localStorage` (`docs-theme-preference`). A short synchronous script in each page `<head>` applies the stored choice before first paint to limit flash of the wrong theme.
+- [`scripts/inject_docs_theme_assets.py`](../scripts/inject_docs_theme_assets.py): inserts the `docs-theme.css` `<link>` (after `docs.css`) and the early theme script into `docs/**/*.html` when adding or normalizing pages.
+
+### Changed
+
+- Shared styling refactored around **CSS custom properties** in [`docs/assets/docs.css`](assets/docs.css), [`docs/assets/docs-site-nav.css`](assets/docs-site-nav.css), [`docs/assets/internal-layout.css`](assets/internal-layout.css), and [`docs/backlog/backlog.css`](backlog/backlog.css) so light and dark themes stay consistent (navigation, search, tables, ADR steppers, backlog pills, internal sidebar, diagrams).
+- **Top navigation:** removed the rotating conic **outline** treatment from the **⭐Backlog** pill so it matches other internal links; theme switcher sits in a dedicated top row (`.top-nav__theme-bar`) above the Internal / Code cards.
+- **Motion:** slowed the animated **sidebar “SHOW MENU”** control border in [`docs/assets/internal-layout.css`](assets/internal-layout.css) and the **ADR “Current status”** pill rim in [`docs/assets/docs.css`](assets/docs.css) for calmer motion.
+
 ## 2026-04-17
 
 ### Added

--- a/docs/adr/0000-template.html
+++ b/docs/adr/0000-template.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR template</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0000-template.html
+++ b/docs/adr/0000-template.html
@@ -15,65 +15,7 @@
   <main class="container" data-adr-weight="-1">
     <h1>ADR &lt;number&gt;: &lt;title&gt;</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>How to set status (author reference)</summary>
-      <p class="small">
-        On <code>&lt;main&gt;</code>, set one attribute <code>data-adr-weight</code> to the <strong>current</strong>
-        milestone (−1 … 7). The page derives <strong>Current status</strong> and the <strong>Status log</strong> from that
-        number. Full policy: <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a>.
-      </p>
-      <table>
-        <caption>Milestone scale (single order 0 → 7)</caption>
-        <thead>
-          <tr>
-            <th>Value</th>
-            <th>Meaning (current milestone)</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>-1</code></td>
-            <td>Status not set (or unknown)</td>
-          </tr>
-          <tr>
-            <td><code>0</code></td>
-            <td><strong>Decision</strong> — Proposed</td>
-          </tr>
-          <tr>
-            <td><code>1</code></td>
-            <td><strong>Decision</strong> — Accepted</td>
-          </tr>
-          <tr>
-            <td><code>2</code></td>
-            <td><strong>Decision</strong> — Superseded</td>
-          </tr>
-          <tr>
-            <td><code>3</code></td>
-            <td><strong>Documentation</strong> — Draft</td>
-          </tr>
-          <tr>
-            <td><code>4</code></td>
-            <td><strong>Documentation</strong> — Ready</td>
-          </tr>
-          <tr>
-            <td><code>5</code></td>
-            <td><strong>Implementation</strong> — Not started</td>
-          </tr>
-          <tr>
-            <td><code>6</code></td>
-            <td><strong>Implementation</strong> — In progress</td>
-          </tr>
-          <tr>
-            <td><code>7</code></td>
-            <td><strong>Implementation</strong> — Done</td>
-          </tr>
-        </tbody>
-      </table>
-      <p class="small">
-        Example: <code>data-adr-weight="4"</code> → <strong>Current status</strong> is Documentation · Ready. Invalid
-        values are clamped in <code>docs/assets/docs-nav.js</code>.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-template"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0001-docs-as-code.html
+++ b/docs/adr/0001-docs-as-code.html
@@ -14,14 +14,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0001: Adopt Docs as Code</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0001-docs-as-code.html
+++ b/docs/adr/0001-docs-as-code.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0001: Adopt Docs as Code</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0002-testing-policy.html
+++ b/docs/adr/0002-testing-policy.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0002: Mandatory API Testing Policy</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0002-testing-policy.html
+++ b/docs/adr/0002-testing-policy.html
@@ -14,14 +14,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0002: Mandatory API Testing Policy</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0003-error-contract-governance.html
+++ b/docs/adr/0003-error-contract-governance.html
@@ -14,14 +14,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0003: Error Contract Governance</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0003-error-contract-governance.html
+++ b/docs/adr/0003-error-contract-governance.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0003: Error Contract Governance</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0004-api-versioning-policy.html
+++ b/docs/adr/0004-api-versioning-policy.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0004: API Versioning Policy</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0004-api-versioning-policy.html
+++ b/docs/adr/0004-api-versioning-policy.html
@@ -14,14 +14,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0004: API Versioning Policy</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0005-api-security-defaults.html
+++ b/docs/adr/0005-api-security-defaults.html
@@ -14,14 +14,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0005: API Security Defaults</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0005-api-security-defaults.html
+++ b/docs/adr/0005-api-security-defaults.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0005: API Security Defaults</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0006-idempotency-write-operations.html
+++ b/docs/adr/0006-idempotency-write-operations.html
@@ -15,14 +15,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0006: Idempotency For Write Operations</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0006-idempotency-write-operations.html
+++ b/docs/adr/0006-idempotency-write-operations.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0006: Idempotency For Write Operations</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0007-openapi-governance-and-usability-standard.html
+++ b/docs/adr/0007-openapi-governance-and-usability-standard.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0007: OpenAPI Governance and Usability Standard</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0007-openapi-governance-and-usability-standard.html
+++ b/docs/adr/0007-openapi-governance-and-usability-standard.html
@@ -15,14 +15,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0007: OpenAPI Governance and Usability Standard</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0008-make-command-taxonomy-and-workflow-entrypoints.html
+++ b/docs/adr/0008-make-command-taxonomy-and-workflow-entrypoints.html
@@ -15,14 +15,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0008: Make Command Taxonomy and Workflow Entrypoints</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0008-make-command-taxonomy-and-workflow-entrypoints.html
+++ b/docs/adr/0008-make-command-taxonomy-and-workflow-entrypoints.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0008: Make Command Taxonomy and Workflow Entrypoints</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0009-health-readiness-and-observability.html
+++ b/docs/adr/0009-health-readiness-and-observability.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0009: Health, Readiness, and Prometheus Observability</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0009-health-readiness-and-observability.html
+++ b/docs/adr/0009-health-readiness-and-observability.html
@@ -14,14 +14,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0009: Health, Readiness, and Prometheus Observability</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0010-env-profiles-and-config-governance.html
+++ b/docs/adr/0010-env-profiles-and-config-governance.html
@@ -14,14 +14,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0010: Environment Profiles and Config Governance</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0010-env-profiles-and-config-governance.html
+++ b/docs/adr/0010-env-profiles-and-config-governance.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0010: Environment Profiles and Config Governance</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0011-slo-sla-error-budget.html
+++ b/docs/adr/0011-slo-sla-error-budget.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0011: SLOs, SLAs, Error Budget, and Monitoring Alerts</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0011-slo-sla-error-budget.html
+++ b/docs/adr/0011-slo-sla-error-budget.html
@@ -14,14 +14,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0011: SLOs, SLAs, Error Budget, and Monitoring Alerts</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0012-testing-strategy-and-load-testing.html
+++ b/docs/adr/0012-testing-strategy-and-load-testing.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0012: Testing Strategy — Automated, Contract, and Load</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0012-testing-strategy-and-load-testing.html
+++ b/docs/adr/0012-testing-strategy-and-load-testing.html
@@ -14,14 +14,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0012: Testing Strategy — Automated, Contract, and Load</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0013-changelog-and-release-notes.html
+++ b/docs/adr/0013-changelog-and-release-notes.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0013: Changelog and Release Notes</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0013-changelog-and-release-notes.html
+++ b/docs/adr/0013-changelog-and-release-notes.html
@@ -14,14 +14,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0013: Changelog and Release Notes</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0014-dead-code-analysis-and-repository-hygiene.html
+++ b/docs/adr/0014-dead-code-analysis-and-repository-hygiene.html
@@ -14,14 +14,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0014: Dead Code Analysis and Repository Hygiene</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0014-dead-code-analysis-and-repository-hygiene.html
+++ b/docs/adr/0014-dead-code-analysis-and-repository-hygiene.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0014: Dead Code Analysis and Repository Hygiene</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0015-container-image-and-local-kubernetes.html
+++ b/docs/adr/0015-container-image-and-local-kubernetes.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0015: Container Image and Local Kubernetes</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0015-container-image-and-local-kubernetes.html
+++ b/docs/adr/0015-container-image-and-local-kubernetes.html
@@ -14,14 +14,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0015: Container Image and Local Kubernetes</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0016-python-docstrings-google-style-and-pdoc.html
+++ b/docs/adr/0016-python-docstrings-google-style-and-pdoc.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0016: Python Docstrings (Google Style) and pdoc</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0016-python-docstrings-google-style-and-pdoc.html
+++ b/docs/adr/0016-python-docstrings-google-style-and-pdoc.html
@@ -14,14 +14,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0016: Python Docstrings (Google Style) and pdoc</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0017-branch-naming-and-repository-workflow.html
+++ b/docs/adr/0017-branch-naming-and-repository-workflow.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0017: Branch Naming and Repository Workflow</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0017-branch-naming-and-repository-workflow.html
+++ b/docs/adr/0017-branch-naming-and-repository-workflow.html
@@ -14,14 +14,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0017: Branch Naming and Repository Workflow</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0018-adr-lifecycle-ratification-and-badges.html
+++ b/docs/adr/0018-adr-lifecycle-ratification-and-badges.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0018: ADR lifecycle, status model, and ratification</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0018-adr-lifecycle-ratification-and-badges.html
+++ b/docs/adr/0018-adr-lifecycle-ratification-and-badges.html
@@ -14,14 +14,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0018: ADR lifecycle, status model, and ratification</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>
@@ -54,7 +47,9 @@
         <code>data-adr-weight</code>. That value is the <strong>current milestone</strong>; <strong>Current status</strong>
         and the <strong>Status log</strong> are derived from it (green = passed; yellow = current step except
         <strong>Implementation: Done</strong>, which stays green when current; gray = not yet). Rendering is in
-        <code>docs/assets/docs-nav.js</code> (<code>renderAdr</code>).
+        <code>docs/assets/docs-nav.js</code> (<code>renderLifecycleStatusBlocks</code>). RFC pages under
+        <code>docs/rfc/</code> use the same scale via <code>data-rfc-weight</code> on <code>&lt;main&gt;</code>
+        (see <a href="../rfc/README.html">RFC index</a>).
       </p>
       <p>
         The <a href="./0000-template.html">ADR HTML template</a> is the <strong>author-facing shell</strong>:

--- a/docs/adr/0019-python-dependency-security-pip-audit-and-pinning-policy.html
+++ b/docs/adr/0019-python-dependency-security-pip-audit-and-pinning-policy.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0019: Python dependency security, pip-audit, and pinning policy</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0019-python-dependency-security-pip-audit-and-pinning-policy.html
+++ b/docs/adr/0019-python-dependency-security-pip-audit-and-pinning-policy.html
@@ -15,14 +15,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0019: Python dependency security, pip-audit, and pinning policy</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0020-c4-plantuml-diagram-style-and-conventions.html
+++ b/docs/adr/0020-c4-plantuml-diagram-style-and-conventions.html
@@ -15,14 +15,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0020: C4 views, PlantUML conventions, and shared diagram style</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0020-c4-plantuml-diagram-style-and-conventions.html
+++ b/docs/adr/0020-c4-plantuml-diagram-style-and-conventions.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0020: C4 views, PlantUML conventions, and shared diagram style</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0021-continuous-delivery-github-actions-and-ghcr.html
+++ b/docs/adr/0021-continuous-delivery-github-actions-and-ghcr.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0021: Continuous delivery — GitHub Actions and GitHub Container Registry</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0021-continuous-delivery-github-actions-and-ghcr.html
+++ b/docs/adr/0021-continuous-delivery-github-actions-and-ghcr.html
@@ -15,14 +15,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0021: Continuous delivery — GitHub Actions and GitHub Container Registry</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0022-embedded-swagger-ui-openapi-sandbox.html
+++ b/docs/adr/0022-embedded-swagger-ui-openapi-sandbox.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0022: Embedded Swagger — static validation (superseded)</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0022-embedded-swagger-ui-openapi-sandbox.html
+++ b/docs/adr/0022-embedded-swagger-ui-openapi-sandbox.html
@@ -15,14 +15,7 @@
   <main class="container" data-adr-weight="2">
     <h1>ADR 0022: Embedded Swagger — static OpenAPI validation (superseded)</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <p>

--- a/docs/adr/0023-structured-logging-and-local-elasticsearch.html
+++ b/docs/adr/0023-structured-logging-and-local-elasticsearch.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0023: Structured Logging, Request Correlation, and Local Elasticsearch</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0023-structured-logging-and-local-elasticsearch.html
+++ b/docs/adr/0023-structured-logging-and-local-elasticsearch.html
@@ -14,13 +14,7 @@
   <main class="container" data-adr-weight="4">
     <h1>ADR 0023: Structured Logging, Request Correlation, and Local Elasticsearch</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a>.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
 
       <h2>Ratification</h2>

--- a/docs/adr/0024-architecture-and-quality-assessment-documents.html
+++ b/docs/adr/0024-architecture-and-quality-assessment-documents.html
@@ -15,14 +15,7 @@
   <main class="container" data-adr-weight="8">
     <h1>ADR 0024: Architecture and quality assessment documents(audit format)</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
 
     <section class="card">
       <h2>Ratification</h2>

--- a/docs/adr/0024-architecture-and-quality-assessment-documents.html
+++ b/docs/adr/0024-architecture-and-quality-assessment-documents.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0024: Architecture and quality assessment documents (audit format)</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0025-external-and-internal-api-documentation.html
+++ b/docs/adr/0025-external-and-internal-api-documentation.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0025: External and internal API documentation</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0025-external-and-internal-api-documentation.html
+++ b/docs/adr/0025-external-and-internal-api-documentation.html
@@ -15,14 +15,7 @@
   <main class="container" data-adr-weight="1">
     <h1>ADR 0025: External and internal API documentation</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
 
     <section class="card">
       <h2>Ratification</h2>

--- a/docs/adr/0026-internal-service-documentation-as-source-of-truth.html
+++ b/docs/adr/0026-internal-service-documentation-as-source-of-truth.html
@@ -15,14 +15,7 @@
   <main class="container" data-adr-weight="1">
     <h1>ADR 0026: Internal service documentation as source of truth</h1>
     <div id="docs-top-nav"></div>
-    <details class="adr-weight-help">
-      <summary>ADR status on this page</summary>
-      <p class="small">
-        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
-        <a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a> for what each step means, or the
-        <a href="./0000-template.html">ADR template</a> for the full milestone table.
-      </p>
-    </details>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
 
     <section class="card">
       <h2>Ratification</h2>

--- a/docs/adr/0026-internal-service-documentation-as-source-of-truth.html
+++ b/docs/adr/0026-internal-service-documentation-as-source-of-truth.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0026: Internal service documentation as source of truth</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0027-client-side-docs-search-index-and-ranking.html
+++ b/docs/adr/0027-client-side-docs-search-index-and-ranking.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR 0027: High-relevance client-side docs search (inverted index, IDF, and ranking boosts)</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/0027-client-side-docs-search-index-and-ranking.html
+++ b/docs/adr/0027-client-side-docs-search-index-and-ranking.html
@@ -15,6 +15,7 @@
   <main class="container" data-adr-weight="7">
     <h1>ADR 0027: High-relevance client-side docs search (inverted index, IDF, and ranking boosts)</h1>
     <div id="docs-top-nav"></div>
+    <details class="adr-weight-help" data-docs-lifecycle="adr-short"></details>
     <section class="card">
       <h2>Ratification</h2>
       <ul>

--- a/docs/adr/README.html
+++ b/docs/adr/README.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ADR Index</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/adr/README.html
+++ b/docs/adr/README.html
@@ -124,207 +124,177 @@
                         <th>Document</th>
                         <th>Description</th>
                         <th>Decision</th>
-                        <th>Open</th>
                       </tr>
                     </thead>
                     <tbody>
                       <tr>
-                        <td>Template</td>
+                        <td><a href="./0000-template.html">Template</a></td>
                         <td>Copy-paste shell for a new ADR: sections, ratification block, and the full status-milestone table for
                           authors.</td>
-                          <td>—</td>
-                          <td><a href="./0000-template.html">ADR 0000</a></td>
-                        </tr>
-                        <tr>
-                          <td>ADR 0001</td>
-                          <td>Docs as Code: narrative and generated docs live in git and pass the same quality gates as application
+                        <td>—</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0001-docs-as-code.html">ADR 0001</a></td>
+                        <td>Docs as Code: narrative and generated docs live in git and pass the same quality gates as application
                             changes.</td>
-                            <td>Accepted</td>
-                            <td><a href="./0001-docs-as-code.html">ADR 0001</a></td>
-                          </tr>
-                          <tr>
-                            <td>ADR 0002</td>
-                            <td>API changes must include automated tests (happy path + at least one failure); unfinished work does not
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0002-testing-policy.html">ADR 0002</a></td>
+                        <td>API changes must include automated tests (happy path + at least one failure); unfinished work does not
                               ship.</td>
-                              <td>Accepted</td>
-                              <td><a href="./0002-testing-policy.html">ADR 0002</a></td>
-                            </tr>
-                            <tr>
-                              <td>ADR 0003</td>
-                              <td>Stable machine-readable errors: shared transport catalog plus per-entity codes; OpenAPI and tests stay
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0003-error-contract-governance.html">ADR 0003</a></td>
+                        <td>Stable machine-readable errors: shared transport catalog plus per-entity codes; OpenAPI and tests stay
                                 aligned.</td>
-                                <td>Accepted</td>
-                                <td><a href="./0003-error-contract-governance.html">ADR 0003</a></td>
-                              </tr>
-                              <tr>
-                                <td>ADR 0004</td>
-                                <td>Major version in the URL; additive edits inside a major; breaking changes and error semantics need a
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0004-api-versioning-policy.html">ADR 0004</a></td>
+                        <td>Major version in the URL; additive edits inside a major; breaking changes and error semantics need a
                                   deliberate path.</td>
-                                  <td>Accepted</td>
-                                  <td><a href="./0004-api-versioning-policy.html">ADR 0004</a></td>
-                                </tr>
-                                <tr>
-                                  <td>ADR 0005</td>
-                                  <td>Security baseline on protected routes: auth strategy, rate limits, CORS allowlist, headers, and
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0005-api-security-defaults.html">ADR 0005</a></td>
+                        <td>Security baseline on protected routes: auth strategy, rate limits, CORS allowlist, headers, and
                                     request size cap.</td>
-                                    <td>Accepted</td>
-                                    <td><a href="./0005-api-security-defaults.html">ADR 0005</a></td>
-                                  </tr>
-                                  <tr>
-                                    <td>ADR 0006</td>
-                                    <td>Critical writes use <code>Idempotency-Key</code>; server dedupes so retries do not double-apply
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0006-idempotency-write-operations.html">ADR 0006</a></td>
+                        <td>Critical writes use <code>Idempotency-Key</code>; server dedupes so retries do not double-apply
                                       business effects.</td>
-                                      <td>Accepted</td>
-                                      <td><a href="./0006-idempotency-write-operations.html">ADR 0006</a></td>
-                                    </tr>
-                                    <tr>
-                                      <td>ADR 0007</td>
-                                      <td>OpenAPI is the product-facing contract: complete examples, links between operations, snapshots, and CI
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0007-openapi-governance-and-usability-standard.html">ADR 0007</a></td>
+                        <td>OpenAPI is the product-facing contract: complete examples, links between operations, snapshots, and CI
                                         contract checks.</td>
-                                        <td>Accepted</td>
-                                        <td><a href="./0007-openapi-governance-and-usability-standard.html">ADR 0007</a></td>
-                                      </tr>
-                                      <tr>
-                                        <td>ADR 0008</td>
-                                        <td>Make targets split into small primitives versus high-level <code>fix</code> / <code>verify</code> /
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0008-make-command-taxonomy-and-workflow-entrypoints.html">ADR 0008</a></td>
+                        <td>Make targets split into small primitives versus high-level <code>fix</code> / <code>verify</code> /
                                           <code>release-check</code> entrypoints.</td>
-                                          <td>Accepted</td>
-                                          <td><a href="./0008-make-command-taxonomy-and-workflow-entrypoints.html">ADR 0008</a></td>
-                                        </tr>
-                                        <tr>
-                                          <td>ADR 0009</td>
-                                          <td><code>/live</code> vs <code>/ready</code> for orchestrators; Prometheus metrics for latency, status,
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0009-health-readiness-and-observability.html">ADR 0009</a></td>
+                        <td><code>/live</code> vs <code>/ready</code> for orchestrators; Prometheus metrics for latency, status,
                                             and DB—same idea from laptop to prod.</td>
-                                            <td>Accepted</td>
-                                            <td><a href="./0009-health-readiness-and-observability.html">ADR 0009</a></td>
-                                          </tr>
-                                          <tr>
-                                            <td>ADR 0010</td>
-                                            <td>Explicit <code>dev</code> / <code>qa</code> / <code>prod</code> profiles, layered env files, and rules
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0010-env-profiles-and-config-governance.html">ADR 0010</a></td>
+                        <td>Explicit <code>dev</code> / <code>qa</code> / <code>prod</code> profiles, layered env files, and rules
                                               that block unsafe prod settings at startup.</td>
-                                              <td>Accepted</td>
-                                              <td><a href="./0010-env-profiles-and-config-governance.html">ADR 0010</a></td>
-                                            </tr>
-                                            <tr>
-                                              <td>ADR 0011</td>
-                                              <td>SLIs and SLOs (availability, latency, readiness), error-budget style burn signals, and Prometheus
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0011-slo-sla-error-budget.html">ADR 0011</a></td>
+                        <td>SLIs and SLOs (availability, latency, readiness), error-budget style burn signals, and Prometheus
                                                 alerts—targets, not vibes.</td>
-                                                <td>Accepted</td>
-                                                <td><a href="./0011-slo-sla-error-budget.html">ADR 0011</a></td>
-                                              </tr>
-                                              <tr>
-                                                <td>ADR 0012</td>
-                                                <td>Testing map: required API and contract tests in CI; manual where it helps; load tests optional and
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0012-testing-strategy-and-load-testing.html">ADR 0012</a></td>
+                        <td>Testing map: required API and contract tests in CI; manual where it helps; load tests optional and
                                                   tied to observability.</td>
-                                                  <td>Accepted</td>
-                                                  <td><a href="./0012-testing-strategy-and-load-testing.html">ADR 0012</a></td>
-                                                </tr>
-                                                <tr>
-                                                  <td>ADR 0013</td>
-                                                  <td>Root <code>CHANGELOG.md</code> (Keep a Changelog), when CI expects an update, skip tokens, and
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0013-changelog-and-release-notes.html">ADR 0013</a></td>
+                        <td>Root <code>CHANGELOG.md</code> (Keep a Changelog), when CI expects an update, skip tokens, and
                                                     optional LLM-assisted drafting.</td>
-                                                    <td>Accepted</td>
-                                                    <td><a href="./0013-changelog-and-release-notes.html">ADR 0013</a></td>
-                                                  </tr>
-                                                  <tr>
-                                                    <td>ADR 0014</td>
-                                                    <td>Hygiene: Ruff blocks unused imports on every PR; Vulture runs on a schedule for deeper dead
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0014-dead-code-analysis-and-repository-hygiene.html">ADR 0014</a></td>
+                        <td>Hygiene: Ruff blocks unused imports on every PR; Vulture runs on a schedule for deeper dead
                                                       code—delete only after triage.</td>
-                                                      <td>Accepted</td>
-                                                      <td><a href="./0014-dead-code-analysis-and-repository-hygiene.html">ADR 0014</a></td>
-                                                    </tr>
-                                                    <tr>
-                                                      <td>ADR 0015</td>
-                                                      <td>Reproducible Docker image (migrations + app entrypoint) and example Kubernetes for local learning—not
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0015-container-image-and-local-kubernetes.html">ADR 0015</a></td>
+                        <td>Reproducible Docker image (migrations + app entrypoint) and example Kubernetes for local learning—not
                                                         a full production chart.</td>
-                                                        <td>Accepted</td>
-                                                        <td><a href="./0015-container-image-and-local-kubernetes.html">ADR 0015</a></td>
-                                                      </tr>
-                                                      <tr>
-                                                        <td>ADR 0016</td>
-                                                        <td>Google-style docstrings in Python; generated API HTML via pdoc so internal modules stay as reviewable
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0016-python-docstrings-google-style-and-pdoc.html">ADR 0016</a></td>
+                        <td>Google-style docstrings in Python; generated API HTML via pdoc so internal modules stay as reviewable
                                                           as HTTP docs.</td>
-                                                          <td>Accepted</td>
-                                                          <td><a href="./0016-python-docstrings-google-style-and-pdoc.html">ADR 0016</a></td>
-                                                        </tr>
-                                                        <tr>
-                                                          <td>ADR 0017</td>
-                                                          <td>Branch naming, trunk flow on <code>main</code>, semver tags, and how rare hotfixes get forward-ported.
-                                                          </td>
-                                                          <td>Accepted</td>
-                                                          <td><a href="./0017-branch-naming-and-repository-workflow.html">ADR 0017</a></td>
-                                                        </tr>
-                                                        <tr>
-                                                          <td>ADR 0018</td>
-                                                          <td>How ADR status is shown, how decisions are ratified (Issue + PR), and where doc-only changes are
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0017-branch-naming-and-repository-workflow.html">ADR 0017</a></td>
+                        <td>Branch naming, trunk flow on <code>main</code>, semver tags, and how rare hotfixes get forward-ported.</td>
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a></td>
+                        <td>How ADR status is shown, how decisions are ratified (Issue + PR), and where doc-only changes are
                                                             summarized.</td>
-                                                            <td>Accepted</td>
-                                                            <td><a href="./0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a></td>
-                                                          </tr>
-                                                          <tr>
-                                                            <td>ADR 0019</td>
-                                                            <td>Pinned <code>requirements.txt</code>, <code>pip-audit</code> in Make/CI, severity-based response, and
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0019-python-dependency-security-pip-audit-and-pinning-policy.html">ADR 0019</a></td>
+                        <td>Pinned <code>requirements.txt</code>, <code>pip-audit</code> in Make/CI, severity-based response, and
                                                               time-boxed exceptions.</td>
-                                                              <td>Accepted</td>
-                                                              <td><a href="./0019-python-dependency-security-pip-audit-and-pinning-policy.html">ADR 0019</a></td>
-                                                            </tr>
-                                                            <tr>
-                                                              <td>ADR 0020</td>
-                                                              <td>Architecture views in PlantUML using C4 levels, shared skin, sequence defaults, and Kroki-rendered
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0020-c4-plantuml-diagram-style-and-conventions.html">ADR 0020</a></td>
+                        <td>Architecture views in PlantUML using C4 levels, shared skin, sequence defaults, and Kroki-rendered
                                                                 PNGs in docs.</td>
-                                                                <td>Accepted</td>
-                                                                <td><a href="./0020-c4-plantuml-diagram-style-and-conventions.html">ADR 0020</a></td>
-                                                              </tr>
-                                                              <tr>
-                                                                <td>ADR 0021</td>
-                                                                <td>After green CI on <code>main</code> / version tags, GitHub Actions builds the image and pushes to
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0021-continuous-delivery-github-actions-and-ghcr.html">ADR 0021</a></td>
+                        <td>After green CI on <code>main</code> / version tags, GitHub Actions builds the image and pushes to
                                                                   GHCR—runtime secrets stay outside the workflow.</td>
-                                                                  <td>Accepted</td>
-                                                                  <td><a href="./0021-continuous-delivery-github-actions-and-ghcr.html">ADR 0021</a></td>
-                                                                </tr>
-                                                                <tr>
-                                                                  <td>ADR 0022</td>
-                                                                  <td><strong>Superseded</strong> attempt at browser-side request validation; static explorer remains
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0022-embedded-swagger-ui-openapi-sandbox.html">ADR 0022</a></td>
+                        <td><strong>Superseded</strong> attempt at browser-side request validation; static explorer remains
                                                                     browse-only—contract checks live in CI.</td>
-                                                                    <td>Superseded</td>
-                                                                    <td><a href="./0022-embedded-swagger-ui-openapi-sandbox.html">ADR 0022</a></td>
-                                                                  </tr>
-                                                                  <tr>
-                                                                    <td>ADR 0023</td>
-                                                                    <td>NDJSON logs, <code>X-Request-Id</code>, optional Docker Compose (Elasticsearch, Kibana, Filebeat) for
+                        <td>Superseded</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0023-structured-logging-and-local-elasticsearch.html">ADR 0023</a></td>
+                        <td>NDJSON logs, <code>X-Request-Id</code>, optional Docker Compose (Elasticsearch, Kibana, Filebeat) for
                                                                       local search—tracing in ES deferred to OpenTelemetry work.</td>
-                                                                      <td>Accepted</td>
-                                                                      <td><a href="./0023-structured-logging-and-local-elasticsearch.html">ADR 0023</a></td>
-                                                                    </tr>
-                                                                    <tr>
-                                                                      <td>ADR 0024</td>
-                                                                      <td>Architecture and quality assessments live under <code>docs/audit/</code> as dated HTML: reference
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0024-architecture-and-quality-assessment-documents.html">ADR 0024</a></td>
+                        <td>Architecture and quality assessments live under <code>docs/audit/</code> as dated HTML: reference
                                                                         table, mapping/scores, findings, mitigation, history—complementing ADRs and runbooks.</td>
-                                                                        <td>Accepted</td>
-                                                                        <td><a href="./0024-architecture-and-quality-assessment-documents.html">ADR 0024</a></td>
-                                                                      </tr>
-                                                                      <tr>
-                                                                        <td>ADR 0025</td>
-                                                                        <td>Split external (OpenAPI + changelog) vs internal (<code>docs/internal/</code>) documentation; OpenAPI
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0025-external-and-internal-api-documentation.html">ADR 0025</a></td>
+                        <td>Split external (OpenAPI + changelog) vs internal (<code>docs/internal/</code>) documentation; OpenAPI
                                                                           baseline is the sole normative HTTP contract for integrators.</td>
-                                                                          <td>Accepted</td>
-                                                                          <td><a href="./0025-external-and-internal-api-documentation.html">ADR 0025</a></td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                          <td>ADR 0026</td>
-                                                                          <td>Internal HTML under <code>docs/internal/</code> is the authoritative engineering narrative for
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0026-internal-service-documentation-as-source-of-truth.html">ADR 0026</a></td>
+                        <td>Internal HTML under <code>docs/internal/</code> is the authoritative engineering narrative for
                                                                             documented behavior, business rules, and ops expectations; history tables + git.</td>
-                                                                            <td>Accepted</td>
-                                                                            <td><a href="./0026-internal-service-documentation-as-source-of-truth.html">ADR 0026</a></td>
-                                                                          </tr>
-                                                                          <tr>
-                                                                            <td>ADR 0027</td>
-                                                                            <td>Defines full-site client-side search for docs: offline index generation, lexical normalization,
+                        <td>Accepted</td>
+                      </tr>
+                      <tr>
+                        <td><a href="./0027-client-side-docs-search-index-and-ranking.html">ADR 0027</a></td>
+                        <td>Defines full-site client-side search for docs: offline index generation, lexical normalization,
                                                                               weighted relevance scoring, telemetry KPI formulas, and technical DB storage constraints.</td>
-                                                                              <td>Accepted</td>
-                                                                              <td><a href="./0027-client-side-docs-search-index-and-ranking.html">ADR 0027</a></td>
-                                                                            </tr>
-                                                                          </tbody>
+                        <td>Accepted</td>
+                      </tr>
+                    </tbody>
                                                                         </table>
                                                                       </section>
                                                                       <section class="card">

--- a/docs/assets/audit-score-legend-fragment.html
+++ b/docs/assets/audit-score-legend-fragment.html
@@ -1,7 +1,10 @@
 <!doctype html>
-<html><head>  <link rel="stylesheet" href="./docs.css">
-  <script defer src="./docs-nav.js"></script>
+<html><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
   <link rel="stylesheet" href="./docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
+  <script defer src="./docs-nav.js"></script>
+  <link rel="stylesheet" href="./docs.css">
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
 </head><body><aside class="audit-score-legend" role="note" aria-labelledby="audit-score-legend-title">
 <h3 class="audit-score-legend-title" id="audit-score-legend-title">Score scale (1–10)</h3>

--- a/docs/assets/docs-nav.js
+++ b/docs/assets/docs-nav.js
@@ -117,6 +117,75 @@ const DOCS_SEARCH_SUCCESS_WINDOW_MS = 60_000;
 const DOCS_FEEDBACK_REPOSITORY = "iboiarkin96/study_bot";
 const DOCS_FEEDBACK_TEMPLATE = "docs_feedback.yml";
 const DOCS_FEEDBACK_LABELS = ["docs-feedback"];
+const DOCS_THEME_STORAGE_KEY = "docs-theme-preference";
+
+function getStoredDocsTheme() {
+  try {
+    return window.localStorage.getItem(DOCS_THEME_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function setStoredDocsTheme(mode) {
+  try {
+    if (mode === "system" || mode === null) {
+      window.localStorage.removeItem(DOCS_THEME_STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(DOCS_THEME_STORAGE_KEY, mode);
+    }
+  } catch {
+    // Ignore storage failures; theme toggle still updates the live document.
+  }
+}
+
+function applyDocsThemeFromMode(mode) {
+  const root = document.documentElement;
+  if (mode === "dark") {
+    root.setAttribute("data-theme", "dark");
+  } else if (mode === "light") {
+    root.setAttribute("data-theme", "light");
+  } else {
+    root.removeAttribute("data-theme");
+  }
+}
+
+function getEffectiveDocsThemeMode() {
+  const s = getStoredDocsTheme();
+  if (s === "dark" || s === "light") {
+    return s;
+  }
+  return "system";
+}
+
+function cycleDocsTheme() {
+  const order = ["system", "light", "dark"];
+  const cur = getEffectiveDocsThemeMode();
+  const i = order.indexOf(cur);
+  const next = order[(i + 1) % order.length];
+  setStoredDocsTheme(next === "system" ? null : next);
+  applyDocsThemeFromMode(next);
+  syncDocsThemeToggleLabel();
+}
+
+function syncDocsThemeToggleLabel() {
+  const btn = document.querySelector("[data-docs-theme-toggle]");
+  if (!btn) {
+    return;
+  }
+  const mode = getEffectiveDocsThemeMode();
+  const labels = {
+    system: "Theme: Auto",
+    light: "Theme: Light",
+    dark: "Theme: Dark",
+  };
+  btn.textContent = labels[mode];
+  btn.setAttribute(
+    "title",
+    "Cycle documentation color theme: follow system → light → dark → follow system",
+  );
+  btn.setAttribute("aria-label", `${labels[mode]}. Activate to cycle documentation color theme.`);
+}
 let docsSearchIndexPromise = null;
 let docsSearchSessionId = null;
 let docsSearchQuerySeq = 0;
@@ -679,7 +748,7 @@ function renderTopNav() {
     { label: "Home", target: "index.html" },
     { label: "Internal docs", target: "internal/README.html" },
     { label: "API assessment reports", target: "audit/README.html" },
-    { label: "⭐Backlog", target: "backlog/README.html", className: "top-nav__link--backlog" },
+    { label: "⭐Backlog", target: "backlog/README.html" },
   ];
   const publicItems = [
     { label: "OpenAPI explorer", target: "openapi/openapi-explorer.html" },
@@ -753,6 +822,20 @@ function renderTopNav() {
   groups.appendChild(internalSection);
   groups.appendChild(split);
   groups.appendChild(publicSection);
+
+  const themeBtn = document.createElement("button");
+  themeBtn.type = "button";
+  themeBtn.className = "top-nav__theme-btn";
+  themeBtn.setAttribute("data-docs-theme-toggle", "1");
+  themeBtn.textContent = "Theme: Auto";
+  themeBtn.addEventListener("click", () => {
+    cycleDocsTheme();
+  });
+  const themeBar = document.createElement("div");
+  themeBar.className = "top-nav__theme-bar";
+  themeBar.appendChild(themeBtn);
+
+  nav.appendChild(themeBar);
   nav.appendChild(groups);
   mountDocsSearch(nav, fromDir);
 
@@ -1315,6 +1398,8 @@ function initInPageTocScrollSpy() {
 
 document.addEventListener("DOMContentLoaded", () => {
   renderTopNav();
+  applyDocsThemeFromMode(getEffectiveDocsThemeMode());
+  syncDocsThemeToggleLabel();
   const main = document.querySelector("main.container");
   if (main) {
     renderAdr(main);

--- a/docs/assets/docs-nav.js
+++ b/docs/assets/docs-nav.js
@@ -114,10 +114,112 @@ const DOCS_SEARCH_MAX_RESULTS = 10;
 const DOCS_SEARCH_DEBOUNCE_MS = 120;
 const DOCS_SEARCH_MAX_PREFIX_EXPANSIONS = 24;
 const DOCS_SEARCH_SUCCESS_WINDOW_MS = 60_000;
-const DOCS_FEEDBACK_REPOSITORY = "iboiarkin96/study_bot";
+const DOCS_FEEDBACK_REPOSITORY = "iboiarkin96/etr-study-api";
 const DOCS_FEEDBACK_TEMPLATE = "docs_feedback.yml";
 const DOCS_FEEDBACK_LABELS = ["docs-feedback"];
 const DOCS_THEME_STORAGE_KEY = "docs-theme-preference";
+
+/** Bump when the shared ADR/RFC lifecycle help copy in `injectDocsLifecycleHelp` changes. */
+const DOCS_LIFECYCLE_HELP_SNIPPET_VERSION = "1";
+
+function docsPageDir() {
+  const rel = currentDocsRelPath();
+  const i = rel.lastIndexOf("/");
+  return i >= 0 ? rel.slice(0, i) : "";
+}
+
+function docsLifecycleHelpHref(targetRelPath) {
+  return relHref(docsPageDir(), targetRelPath);
+}
+
+/**
+ * Fills `<details class="adr-weight-help|rfc-weight-help" data-docs-lifecycle="…">` from a single source
+ * so policy wording and links stay consistent across ADR/RFC pages (see DOCS_LIFECYCLE_HELP_SNIPPET_VERSION).
+ */
+function injectDocsLifecycleHelp() {
+  const v = DOCS_LIFECYCLE_HELP_SNIPPET_VERSION;
+  for (const el of document.querySelectorAll("details[data-docs-lifecycle]")) {
+    const kind = el.getAttribute("data-docs-lifecycle");
+    el.setAttribute("data-docs-lifecycle-version", v);
+    if (kind === "adr-short") {
+      const h18 = docsLifecycleHelpHref("adr/0018-adr-lifecycle-ratification-and-badges.html");
+      const h0 = docsLifecycleHelpHref("adr/0000-template.html");
+      el.innerHTML = `<summary>ADR status on this page</summary>
+      <p class="small">
+        The lifecycle bar uses <code>data-adr-weight</code> on <code>&lt;main&gt;</code> (values −1…7). See
+        <a href="${h18}">ADR 0018</a> for what each step means, or the
+        <a href="${h0}">ADR template</a> for the full milestone table.
+      </p>`;
+    } else if (kind === "rfc-short") {
+      const h18 = docsLifecycleHelpHref("adr/0018-adr-lifecycle-ratification-and-badges.html");
+      el.innerHTML = `<summary>RFC status on this page</summary>
+      <p class="small">
+        The lifecycle bar uses <code>data-rfc-weight</code> on <code>&lt;main&gt;</code> (values −1…7), the same milestone
+        scale as ADRs (<a href="${h18}">ADR 0018</a>). Update the attribute
+        when this document\u2019s milestone changes.
+      </p>`;
+    } else if (kind === "adr-template") {
+      const h18 = docsLifecycleHelpHref("adr/0018-adr-lifecycle-ratification-and-badges.html");
+      el.innerHTML = `<summary>How to set status (author reference)</summary>
+      <p class="small">
+        On <code>&lt;main&gt;</code>, set one attribute <code>data-adr-weight</code> to the <strong>current</strong>
+        milestone (−1 … 7). The page derives <strong>Current status</strong> and the <strong>Status log</strong> from that
+        number. Full policy: <a href="${h18}">ADR 0018</a>.
+      </p>
+      <table>
+        <caption>Milestone scale (single order 0 → 7)</caption>
+        <thead>
+          <tr>
+            <th>Value</th>
+            <th>Meaning (current milestone)</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>-1</code></td>
+            <td>Status not set (or unknown)</td>
+          </tr>
+          <tr>
+            <td><code>0</code></td>
+            <td><strong>Decision</strong> — Proposed</td>
+          </tr>
+          <tr>
+            <td><code>1</code></td>
+            <td><strong>Decision</strong> — Accepted</td>
+          </tr>
+          <tr>
+            <td><code>2</code></td>
+            <td><strong>Decision</strong> — Superseded</td>
+          </tr>
+          <tr>
+            <td><code>3</code></td>
+            <td><strong>Documentation</strong> — Draft</td>
+          </tr>
+          <tr>
+            <td><code>4</code></td>
+            <td><strong>Documentation</strong> — Ready</td>
+          </tr>
+          <tr>
+            <td><code>5</code></td>
+            <td><strong>Implementation</strong> — Not started</td>
+          </tr>
+          <tr>
+            <td><code>6</code></td>
+            <td><strong>Implementation</strong> — In progress</td>
+          </tr>
+          <tr>
+            <td><code>7</code></td>
+            <td><strong>Implementation</strong> — Done</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="small">
+        Example: <code>data-adr-weight="4"</code> → <strong>Current status</strong> is Documentation · Ready. Invalid
+        values are clamped in <code>docs/assets/docs-nav.js</code>.
+      </p>`;
+    }
+  }
+}
 
 function getStoredDocsTheme() {
   try {
@@ -978,7 +1080,10 @@ function renderTopNav() {
   host.replaceChildren(breadcrumbNav, nav);
 }
 
-/** ADR: single `data-adr-weight` on <main> (−1…7) → current status + linear status log. */
+/**
+ * ADR / RFC lifecycle: one weight on `<main>` (−1…7) → current status + linear status log.
+ * ADRs use `data-adr-weight`; RFCs use `data-rfc-weight` (same steps as ADR 0018).
+ */
 
 const ADR_STEPS = [
   { w: 0, axis: "Decision", label: "Proposed" },
@@ -1003,10 +1108,6 @@ function parseAdrWeightValue(raw) {
     return 7;
   }
   return n;
-}
-
-function adrCurrentWeight(main) {
-  return parseAdrWeightValue(main.getAttribute("data-adr-weight"));
 }
 
 function stepKind(stepWeight, globalMax) {
@@ -1103,21 +1204,21 @@ function renderAdrStatusLogAfter(anchor, globalMax) {
   anchor.insertAdjacentElement("afterend", wrap);
 }
 
-function mainHasAdrWeight(main) {
-  return main.hasAttribute("data-adr-weight");
-}
-
-function renderAdr(main) {
-  if (!mainHasAdrWeight(main)) {
-    return;
-  }
-
+function renderLifecycleStatusBlocks(main) {
   const nav = main.querySelector("nav.top-nav");
   if (!nav) {
     return;
   }
+  const attr = main.hasAttribute("data-adr-weight")
+    ? "data-adr-weight"
+    : main.hasAttribute("data-rfc-weight")
+      ? "data-rfc-weight"
+      : null;
+  if (!attr) {
+    return;
+  }
 
-  const globalMax = adrCurrentWeight(main);
+  const globalMax = parseAdrWeightValue(main.getAttribute(attr));
 
   const anchor = renderAdrCurrentStatus(nav, globalMax);
   renderAdrStatusLogAfter(anchor, globalMax);
@@ -1611,7 +1712,6 @@ function initDocsSiteFooter() {
   }
 
   addLink("index.html", "Documentation home");
-  addLink("internal/developers.html", "Contributors");
   const gh = document.createElement("a");
   gh.href = `https://github.com/${DOCS_FEEDBACK_REPOSITORY}`;
   gh.textContent = "GitHub";
@@ -1622,7 +1722,7 @@ function initDocsSiteFooter() {
   const meta = document.createElement("p");
   meta.className = "docs-site-footer__meta";
   meta.textContent =
-    "Static HTML under docs/. Product changes are recorded in the repository root CHANGELOG; documentation-only changes are listed in docs/CHANGELOG.md.";
+    "Static HTML under docs/.\nProduct changes are recorded in the repository root CHANGELOG; documentation-only changes are listed in docs/CHANGELOG.md."
 
   inner.appendChild(nav);
   inner.appendChild(meta);
@@ -1631,12 +1731,13 @@ function initDocsSiteFooter() {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
+  injectDocsLifecycleHelp();
   renderTopNav();
   applyDocsThemeFromMode(getEffectiveDocsThemeMode());
   syncDocsThemeToggleLabel();
   const main = document.querySelector("main.container");
   if (main) {
-    renderAdr(main);
+    renderLifecycleStatusBlocks(main);
   }
   injectAuditScoreLegends();
   injectDocsFeedbackCard();

--- a/docs/assets/docs-nav.js
+++ b/docs/assets/docs-nav.js
@@ -735,6 +735,139 @@ function appendTopNavLinks(container, items, fromDir, active) {
   }
 }
 
+/** Hub HTML file for a path prefix (directory trail), or null if there is no index page. */
+function docsHubHrefForPrefix(prefix) {
+  const hubs = {
+    adr: "adr/README.html",
+    api: "api/index.html",
+    audit: "audit/README.html",
+    backlog: "backlog/README.html",
+    developer: "developer/README.html",
+    howto: "howto/README.html",
+    internal: "internal/README.html",
+    "internal/api": "internal/api/README.html",
+    "internal/api/user": "internal/api/user/index.html",
+    openapi: "openapi/openapi-explorer.html",
+    rfc: "rfc/README.html",
+    runbooks: "runbooks/README.html",
+  };
+  return hubs[prefix] || null;
+}
+
+/** Human-readable label for a directory prefix (path segments joined by "/"). */
+function docsBreadcrumbLabelForPrefix(prefix) {
+  const labels = {
+    adr: "ADRs",
+    api: "API reference",
+    audit: "Assessments",
+    backlog: "Backlog",
+    developer: "Developer guides",
+    howto: "How-to guides",
+    internal: "Internal docs",
+    "internal/api": "Internal API",
+    "internal/api/user": "User",
+    "internal/api/user/operations": "Operations",
+    openapi: "OpenAPI",
+    rfc: "RFCs",
+    runbooks: "Runbooks",
+    assets: "Assets",
+  };
+  if (labels[prefix]) {
+    return labels[prefix];
+  }
+  const last = prefix.includes("/") ? prefix.slice(prefix.lastIndexOf("/") + 1) : prefix;
+  if (!last) {
+    return prefix;
+  }
+  return last.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function docsBreadcrumbCurrentLabel(fileName) {
+  const t = document.title.trim();
+  if (t) {
+    const first = t.split(/\s[—–-]\s/)[0].trim();
+    if (first) {
+      return first;
+    }
+  }
+  const stem = fileName.replace(/\.html?$/i, "");
+  return stem.replace(/-/g, " ");
+}
+
+/**
+ * @returns {{ label: string, href?: string, current?: boolean }[]}
+ */
+function buildDocsBreadcrumbItems(relPath) {
+  const normalized = relPath.replace(/\\/g, "/");
+  if (normalized === "index.html") {
+    return [{ label: "Documentation", current: true }];
+  }
+
+  const parts = normalized.split("/");
+  const fileName = parts.pop() || "";
+  const dirParts = parts;
+  const fullPath = normalized;
+
+  const crumbs = [{ label: "Documentation", href: "index.html" }];
+
+  let prefix = "";
+  for (let i = 0; i < dirParts.length; i++) {
+    prefix = i === 0 ? dirParts[0] : `${prefix}/${dirParts[i]}`;
+    const hub = docsHubHrefForPrefix(prefix);
+    const hubIsThisPage =
+      hub &&
+      hub === fullPath &&
+      (fileName === "README.html" || fileName === "index.html");
+    if (hubIsThisPage) {
+      crumbs.push({ label: docsBreadcrumbLabelForPrefix(prefix), current: true });
+      return crumbs;
+    }
+    crumbs.push({
+      label: docsBreadcrumbLabelForPrefix(prefix),
+      href: hub || undefined,
+    });
+  }
+
+  crumbs.push({
+    label: docsBreadcrumbCurrentLabel(fileName),
+    current: true,
+  });
+  return crumbs;
+}
+
+function renderDocsBreadcrumbNav(fromDir, relPath) {
+  const items = buildDocsBreadcrumbItems(relPath);
+  const el = document.createElement("nav");
+  el.className = "docs-breadcrumbs";
+  el.setAttribute("aria-label", "Breadcrumb");
+  const ol = document.createElement("ol");
+  ol.className = "docs-breadcrumbs__list";
+  for (const item of items) {
+    const li = document.createElement("li");
+    li.className = "docs-breadcrumbs__item";
+    if (item.current) {
+      const span = document.createElement("span");
+      span.className = "docs-breadcrumbs__current";
+      span.textContent = item.label;
+      span.setAttribute("aria-current", "page");
+      li.appendChild(span);
+    } else if (item.href) {
+      const a = document.createElement("a");
+      a.href = relHref(fromDir, item.href);
+      a.textContent = item.label;
+      li.appendChild(a);
+    } else {
+      const span = document.createElement("span");
+      span.className = "docs-breadcrumbs__text";
+      span.textContent = item.label;
+      li.appendChild(span);
+    }
+    ol.appendChild(li);
+  }
+  el.appendChild(ol);
+  return el;
+}
+
 function renderTopNav() {
   const host = document.getElementById("docs-top-nav");
   if (!host) {
@@ -839,8 +972,10 @@ function renderTopNav() {
   nav.appendChild(groups);
   mountDocsSearch(nav, fromDir);
 
+  const breadcrumbNav = renderDocsBreadcrumbNav(fromDir, relPath);
+
   /* Keep `#docs-top-nav` in the DOM — `initAutoInPageToc` and formatters anchor off this host. */
-  host.replaceChildren(nav);
+  host.replaceChildren(breadcrumbNav, nav);
 }
 
 /** ADR: single `data-adr-weight` on <main> (−1…7) → current status + linear status log. */
@@ -1396,6 +1531,105 @@ function initInPageTocScrollSpy() {
   updateActive();
 }
 
+/** Scroll-to-top control: visible when the viewport is near the bottom of a scrollable page. */
+function initBackToTopButton() {
+  const root = document.documentElement;
+  const thresholdPx = 320;
+  const minScrollExtra = 100;
+
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "docs-back-to-top";
+  btn.setAttribute("aria-label", "Back to top");
+  btn.setAttribute("title", "Back to top");
+  btn.setAttribute("aria-hidden", "true");
+  btn.tabIndex = -1;
+  btn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg>`;
+
+  function pageIsScrollable() {
+    return root.scrollHeight > window.innerHeight + minScrollExtra;
+  }
+
+  function isNearBottom() {
+    return window.scrollY + window.innerHeight >= root.scrollHeight - thresholdPx;
+  }
+
+  function updateVisibility() {
+    const show = pageIsScrollable() && isNearBottom();
+    btn.classList.toggle("docs-back-to-top--visible", show);
+    btn.setAttribute("aria-hidden", show ? "false" : "true");
+    btn.tabIndex = show ? 0 : -1;
+  }
+
+  btn.addEventListener("click", () => {
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    window.scrollTo({ top: 0, behavior: reduceMotion ? "auto" : "smooth" });
+  });
+
+  window.addEventListener(
+    "scroll",
+    () => {
+      updateVisibility();
+    },
+    { passive: true },
+  );
+  window.addEventListener("resize", updateVisibility, { passive: true });
+
+  document.body.appendChild(btn);
+  updateVisibility();
+}
+
+/** Site-wide footer on hand-written docs pages (presence of `#docs-top-nav`). */
+function initDocsSiteFooter() {
+  if (document.getElementById("docs-site-footer")) {
+    return;
+  }
+  if (!document.getElementById("docs-top-nav")) {
+    return;
+  }
+
+  const relPath = currentDocsRelPath();
+  const fromDir = relPath.includes("/") ? relPath.slice(0, relPath.lastIndexOf("/")) : "";
+
+  const footer = document.createElement("footer");
+  footer.id = "docs-site-footer";
+  footer.className = "docs-site-footer";
+  footer.setAttribute("role", "contentinfo");
+
+  const inner = document.createElement("div");
+  inner.className = "container docs-site-footer__inner";
+
+  const nav = document.createElement("nav");
+  nav.className = "docs-site-footer__links";
+  nav.setAttribute("aria-label", "Footer");
+
+  function addLink(href, text) {
+    const a = document.createElement("a");
+    a.href = relHref(fromDir, href);
+    a.textContent = text;
+    nav.appendChild(a);
+  }
+
+  addLink("index.html", "Documentation home");
+  addLink("internal/developers.html", "Contributors");
+  const gh = document.createElement("a");
+  gh.href = `https://github.com/${DOCS_FEEDBACK_REPOSITORY}`;
+  gh.textContent = "GitHub";
+  gh.target = "_blank";
+  gh.rel = "noopener noreferrer";
+  nav.appendChild(gh);
+
+  const meta = document.createElement("p");
+  meta.className = "docs-site-footer__meta";
+  meta.textContent =
+    "Static HTML under docs/. Product changes are recorded in the repository root CHANGELOG; documentation-only changes are listed in docs/CHANGELOG.md.";
+
+  inner.appendChild(nav);
+  inner.appendChild(meta);
+  footer.appendChild(inner);
+  document.body.appendChild(footer);
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   renderTopNav();
   applyDocsThemeFromMode(getEffectiveDocsThemeMode());
@@ -1408,4 +1642,6 @@ document.addEventListener("DOMContentLoaded", () => {
   injectDocsFeedbackCard();
   initAutoInPageToc();
   initInPageTocScrollSpy();
+  initBackToTopButton();
+  initDocsSiteFooter();
 });

--- a/docs/assets/docs-site-nav.css
+++ b/docs/assets/docs-site-nav.css
@@ -1,15 +1,19 @@
 /* Site top navigation (shared).
    Imported by docs/assets/docs.css for hand-written HTML.
-   Loaded alone on pdoc output (docs/api/**) after generation — see scripts/normalize_pdoc_output.py. */
-
-:root {
-  --text: #1f2937;
-  --accent: #2563eb;
-  --line: #dbe3ef;
-}
+   Theme tokens live in docs.css :root (and docs-theme.css). */
 
 .top-nav {
   margin: 8px 0 18px;
+}
+
+/* Theme toggle: own row above Internal / Code so it stays easy to find on all widths. */
+.top-nav__theme-bar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  width: 100%;
+  margin: 0 0 10px;
+  gap: 8px;
 }
 
 .top-nav__groups {
@@ -25,31 +29,31 @@
   padding: 12px 14px;
   border-radius: 14px;
   border: 1px solid var(--line);
-  background: linear-gradient(165deg, #ffffff 0%, #f8fafc 100%);
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  background: var(--nav-group-bg);
+  box-shadow: var(--nav-group-shadow);
 }
 
 .top-nav__group--internal {
   flex: 3 1 420px;
-  border-color: #bfdbfe;
-  background: linear-gradient(165deg, #f8fbff 0%, #f0f7ff 55%, #f8fafc 100%);
-  box-shadow: 0 1px 2px rgba(30, 64, 175, 0.05);
+  border-color: var(--nav-internal-border);
+  background: var(--nav-internal-bg);
+  box-shadow: var(--nav-internal-shadow);
 }
 
 .top-nav__group--internal .top-nav__group-title {
-  color: #1d4ed8;
+  color: var(--nav-internal-title);
 }
 
 .top-nav__group--internal .top-nav__group-hint {
-  color: #60a5fa;
+  color: var(--nav-internal-hint);
 }
 
 .top-nav__group--public {
   flex: 1 1 220px;
   max-width: 100%;
-  border-color: #e9d5ff;
-  background: linear-gradient(165deg, #fdfaff 0%, #faf5ff 55%, #f8fafc 100%);
-  box-shadow: 0 1px 2px rgba(88, 28, 135, 0.05);
+  border-color: var(--nav-public-border);
+  background: var(--nav-public-bg);
+  box-shadow: var(--nav-public-shadow);
 }
 
 .top-nav__group-head {
@@ -61,14 +65,18 @@
 }
 
 .top-nav__group-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
   margin-left: auto;
 }
 
 .top-nav__toggle {
   border: 1px solid var(--line);
   border-radius: 999px;
-  background: #ffffff;
-  color: #475569;
+  background: var(--nav-toggle-bg);
+  color: var(--nav-toggle-fg);
   font-size: 0.78rem;
   line-height: 1.2;
   padding: 4px 10px;
@@ -81,7 +89,29 @@
 }
 
 .top-nav__toggle:focus-visible {
-  outline: 2px solid #93c5fd;
+  outline: 2px solid var(--nav-toggle-focus-ring);
+  outline-offset: 2px;
+}
+
+.top-nav__theme-btn {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--nav-theme-btn-bg);
+  color: var(--nav-theme-btn-fg);
+  font-size: 0.78rem;
+  line-height: 1.2;
+  padding: 4px 10px;
+  cursor: pointer;
+  max-width: 100%;
+}
+
+.top-nav__theme-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.top-nav__theme-btn:focus-visible {
+  outline: 2px solid var(--nav-toggle-focus-ring);
   outline-offset: 2px;
 }
 
@@ -94,21 +124,21 @@
   font-weight: 700;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: #64748b;
+  color: var(--nav-section-title);
 }
 
 .top-nav__group-hint {
   font-size: 0.78rem;
-  color: #94a3b8;
+  color: var(--nav-section-hint);
   line-height: 1.3;
 }
 
 .top-nav__group--public .top-nav__group-title {
-  color: #7e22ce;
+  color: var(--nav-public-title);
 }
 
 .top-nav__group--public .top-nav__group-hint {
-  color: #a78bfa;
+  color: var(--nav-public-hint);
 }
 
 .top-nav__split {
@@ -137,7 +167,7 @@
   border-radius: 999px;
   padding: 5px 12px;
   font-size: 0.9rem;
-  background: #f8fbff;
+  background: var(--nav-link-bg);
   color: var(--text);
 }
 
@@ -148,78 +178,26 @@
 }
 
 .top-nav__links a.is-active {
-  background: #e8efff;
-  border-color: #9db7ff;
-  color: #1e40af;
-}
-
-/* Distinct pill for backlog (optional per-link modifier from docs-nav.js) */
-@property --backlog-border-angle {
-  syntax: "<angle>";
-  inherits: false;
-  initial-value: 0deg;
-}
-
-.top-nav__links a.top-nav__link--backlog {
-  --backlog-border-angle: 0deg;
-  border: 2px solid transparent;
-  color: #1d4ed8;
-  background:
-    linear-gradient(#eff6ff, #eff6ff) padding-box,
-    conic-gradient(
-      from var(--backlog-border-angle),
-      #1e3a8a 0deg 60deg,
-      #93c5fd 60deg 180deg,
-      #1e3a8a 180deg 240deg,
-      #93c5fd 240deg 360deg
-    ) border-box;
-  animation: backlog-border-sweep 2.4s linear infinite;
-}
-
-.top-nav__links a.top-nav__link--backlog:hover {
-  color: #1e40af;
-}
-
-.top-nav__links a.top-nav__link--backlog.is-active {
-  background:
-    linear-gradient(#dbeafe, #dbeafe) padding-box,
-    conic-gradient(
-      from var(--backlog-border-angle),
-      #1e3a8a 0deg 60deg,
-      #60a5fa 60deg 180deg,
-      #1e3a8a 180deg 240deg,
-      #60a5fa 240deg 360deg
-    ) border-box;
-  color: #1e3a8a;
-}
-
-@keyframes backlog-border-sweep {
-  to {
-    --backlog-border-angle: 360deg;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .top-nav__links a.top-nav__link--backlog {
-    animation: none;
-  }
+  background: var(--nav-link-active-bg);
+  border-color: var(--nav-link-active-border);
+  color: var(--nav-link-active-text);
 }
 
 .top-nav__group--public .top-nav__links a {
-  background: #f8fbff;
+  background: var(--nav-link-bg);
   border-color: var(--line);
   color: var(--text);
 }
 
 .top-nav__group--public .top-nav__links a:hover {
-  border-color: #c4b5fd;
-  color: #7e22ce;
+  border-color: var(--nav-public-link-hover-border);
+  color: var(--nav-public-link-hover-text);
 }
 
 .top-nav__group--public .top-nav__links a.is-active {
-  background: #f5f3ff;
-  border-color: #c4b5fd;
-  color: #581c87;
+  background: var(--nav-public-link-active-bg);
+  border-color: var(--nav-public-link-hover-border);
+  color: var(--nav-public-link-active-text);
 }
 
 @media (max-width: 720px) {
@@ -244,7 +222,7 @@ main.pdoc > .pdoc-docs-nav-shell {
   margin: 0 0 1.25rem;
   padding: 0 0 14px;
   border-bottom: 1px solid var(--line);
-  background: linear-gradient(180deg, #f8fafc 0%, rgba(248, 250, 252, 0.4) 100%);
+  background: var(--nav-pdoc-shell-bg);
 }
 
 /* Slightly tighter nav stack inside the API reference column */

--- a/docs/assets/docs-theme.css
+++ b/docs/assets/docs-theme.css
@@ -1,0 +1,392 @@
+/* Dark theme: pair with docs.css (load after docs.css). */
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme]) {
+    color-scheme: dark;
+    --bg: #0d1117;
+    --bg-gradient-top: #010409;
+    --card: #161b22;
+    --text: #e6edf3;
+    --muted: #8b949e;
+    --accent: #58a6ff;
+    --line: #30363d;
+    --inline-code-bg: rgba(110, 118, 129, 0.28);
+    --pre-bg: #0d1117;
+    --pre-fg: #e6edf3;
+    --pre-inset-shadow: rgba(255, 255, 255, 0.04);
+    --table-bg: #161b22;
+    --table-th-bg: #21262d;
+    --card-shadow: 0 3px 10px rgba(0, 0, 0, 0.45);
+    --search-panel-bg: #161b22;
+    --search-result-hover-bg: #1c2d41;
+    --search-result-hover-border: #388bfd;
+    --search-result-preview: #b1bac4;
+    --docs-placeholder: #6e7681;
+    --search-results-shadow: 0 10px 24px rgba(0, 0, 0, 0.55);
+    --time-cell-bg: #21262d;
+    --adr-status-tracks-bg: #161b22;
+    --adr-track-label-color: #8b949e;
+    --adr-step-arrow: #6e7681;
+    --adr-step-border: #30363d;
+    --adr-step-bg: #21262d;
+    --adr-step-text: #c9d1d9;
+    --adr-step-done-bg: #14532d;
+    --adr-step-done-border: #238636;
+    --adr-step-done-text: #bbf7d0;
+    --adr-step-current-bg: #5c4600;
+    --adr-step-current-border: #d29922;
+    --adr-step-current-text: #ffdf5d;
+    --adr-step-todo-bg: #21262d;
+    --adr-step-todo-border: #30363d;
+    --adr-step-todo-text: #8b949e;
+    --adr-step-muted-bg: #21262d;
+    --adr-step-muted-border: #30363d;
+    --adr-step-muted-text: #8b949e;
+    --adr-step-blocked-bg: #5a1e1e;
+    --adr-step-blocked-border: #da3633;
+    --adr-step-blocked-text: #ffd8d8;
+    --adr-status-log-bg: #161b22;
+    --adr-status-log-title: #8b949e;
+    --details-summary-fg: #c9d1d9;
+    --diagram-bg: #161b22;
+    --sys-diagram-bg: linear-gradient(165deg, #161b22 0%, #0d1117 52%);
+    --sys-diagram-frame-shadow:
+      0 1px 0 rgba(0, 0, 0, 0.35),
+      0 12px 32px rgba(0, 0, 0, 0.45);
+    --sys-diagram-head-bg: linear-gradient(90deg, rgba(56, 139, 253, 0.12) 0%, transparent 55%);
+    --sys-diagram-badge-fg: #79c0ff;
+    --sys-diagram-badge-bg: linear-gradient(180deg, #1f2b3d 0%, #1c2128 100%);
+    --sys-diagram-badge-border: #388bfd;
+    --sys-diagram-canvas-bg:
+      radial-gradient(ellipse 90% 60% at 50% 0%, rgba(56, 139, 253, 0.1) 0%, transparent 55%),
+      #0d1117;
+    --sys-diagram-foot-bg: #161b22;
+    --audit-legend-warn-bg: #2d2a1a;
+    --audit-legend-error-bg: #3d2020;
+    --audit-legend-error-fg: #ffb4a8;
+    --badge-default-bg: #1c2128;
+    --badge-success-bg: #14532d;
+    --badge-success-border: #238636;
+    --badge-success-text: #bbf7d0;
+    --badge-warning-bg: #5c4600;
+    --badge-warning-border: #d29922;
+    --badge-warning-text: #ffdf5d;
+    --badge-muted-bg: #21262d;
+    --badge-muted-border: #484f58;
+    --badge-muted-text: #c9d1d9;
+    --badge-danger-bg: #5a1e1e;
+    --badge-danger-border: #da3633;
+    --badge-danger-text: #ffd8d8;
+    --nav-group-bg: linear-gradient(165deg, #161b22 0%, #0d1117 100%);
+    --nav-group-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+    --nav-internal-border: rgba(56, 139, 253, 0.45);
+    --nav-internal-bg: linear-gradient(165deg, #0d1b2a 0%, #0d1117 55%, #161b22 100%);
+    --nav-internal-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+    --nav-internal-title: #79c0ff;
+    --nav-internal-hint: #58a6ff;
+    --nav-public-border: rgba(163, 113, 247, 0.45);
+    --nav-public-bg: linear-gradient(165deg, #1a1425 0%, #161b22 55%, #0d1117 100%);
+    --nav-public-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+    --nav-public-title: #d2a8ff;
+    --nav-public-hint: #a371f7;
+    --nav-section-title: #8b949e;
+    --nav-section-hint: #6e7681;
+    --nav-toggle-bg: #161b22;
+    --nav-toggle-fg: #c9d1d9;
+    --nav-toggle-focus-ring: #388bfd;
+    --nav-link-bg: #1c2128;
+    --nav-link-active-bg: #1d2d41;
+    --nav-link-active-border: #388bfd;
+    --nav-link-active-text: #e6edf3;
+    --nav-public-link-hover-border: #a371f7;
+    --nav-public-link-hover-text: #d2a8ff;
+    --nav-public-link-active-bg: #271f3a;
+    --nav-public-link-active-text: #e6d9ff;
+    --nav-pdoc-shell-bg: linear-gradient(180deg, #161b22 0%, rgba(13, 17, 23, 0.5) 100%);
+    --nav-theme-btn-bg: #161b22;
+    --nav-theme-btn-fg: #c9d1d9;
+    --internal-sidebar-title: #8b949e;
+    --internal-tree-border: #30363d;
+    --internal-tree-hover-bg: #1c2d41;
+    --internal-tree-active-bg: #1d2d41;
+    --internal-tree-active-border: #388bfd;
+    --internal-tree-active-text: #e6edf3;
+    --internal-group-bg: #161b22;
+    --internal-summary-hover-bg: #21262d;
+    --internal-http-tablet-bg: linear-gradient(165deg, #161b22 0%, #0d1117 50%, #1a2332 100%);
+    --internal-http-tablet-path: #e6edf3;
+    --internal-toggle-bg: #161b22;
+    --internal-toggle-fg: #c9d1d9;
+    --internal-toggle-hover-fg: #79c0ff;
+    --adr-cs-base-bg: #161b22;
+    --adr-cs-label: #8b949e;
+    --adr-cs-value: #e6edf3;
+    --audit-score-excellent-bg: #1a3d2e;
+    --audit-score-excellent-border: #238636;
+    --audit-score-good-bg: #4d3c00;
+    --audit-score-good-border: #d29922;
+    --audit-score-needs-bg: #5a1e1e;
+    --audit-score-needs-border: #da3633;
+    --audit-score-legend-border: #30363d;
+    --audit-score-legend-bg: #161b22;
+    --status-todo-bg: #1c2d41;
+    --status-todo-border: #484f58;
+    --status-todo-text: #c9d1d9;
+    --status-in-progress-bg: #4d3c00;
+    --status-in-progress-border: #d29922;
+    --status-in-progress-text: #ffdf5d;
+    --status-done-bg: #14532d;
+    --status-done-border: #238636;
+    --status-done-text: #bbf7d0;
+    --status-blocked-bg: #271f3a;
+    --status-blocked-border: #a371f7;
+    --status-blocked-text: #e6d9ff;
+    --status-rejected-bg: #5a1e1e;
+    --status-rejected-border: #da3633;
+    --status-rejected-text: #ffd8d8;
+  }
+}
+
+html[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: #0d1117;
+  --bg-gradient-top: #010409;
+  --card: #161b22;
+  --text: #e6edf3;
+  --muted: #8b949e;
+  --accent: #58a6ff;
+  --line: #30363d;
+  --inline-code-bg: rgba(110, 118, 129, 0.28);
+  --pre-bg: #0d1117;
+  --pre-fg: #e6edf3;
+  --pre-inset-shadow: rgba(255, 255, 255, 0.04);
+  --table-bg: #161b22;
+  --table-th-bg: #21262d;
+  --card-shadow: 0 3px 10px rgba(0, 0, 0, 0.45);
+  --search-panel-bg: #161b22;
+  --search-result-hover-bg: #1c2d41;
+  --search-result-hover-border: #388bfd;
+  --search-result-preview: #b1bac4;
+  --docs-placeholder: #6e7681;
+  --search-results-shadow: 0 10px 24px rgba(0, 0, 0, 0.55);
+  --time-cell-bg: #21262d;
+  --adr-status-tracks-bg: #161b22;
+  --adr-track-label-color: #8b949e;
+  --adr-step-arrow: #6e7681;
+  --adr-step-border: #30363d;
+  --adr-step-bg: #21262d;
+  --adr-step-text: #c9d1d9;
+  --adr-step-done-bg: #14532d;
+  --adr-step-done-border: #238636;
+  --adr-step-done-text: #bbf7d0;
+  --adr-step-current-bg: #5c4600;
+  --adr-step-current-border: #d29922;
+  --adr-step-current-text: #ffdf5d;
+  --adr-step-todo-bg: #21262d;
+  --adr-step-todo-border: #30363d;
+  --adr-step-todo-text: #8b949e;
+  --adr-step-muted-bg: #21262d;
+  --adr-step-muted-border: #30363d;
+  --adr-step-muted-text: #8b949e;
+  --adr-step-blocked-bg: #5a1e1e;
+  --adr-step-blocked-border: #da3633;
+  --adr-step-blocked-text: #ffd8d8;
+  --adr-status-log-bg: #161b22;
+  --adr-status-log-title: #8b949e;
+  --details-summary-fg: #c9d1d9;
+  --diagram-bg: #161b22;
+  --sys-diagram-bg: linear-gradient(165deg, #161b22 0%, #0d1117 52%);
+  --sys-diagram-frame-shadow:
+    0 1px 0 rgba(0, 0, 0, 0.35),
+    0 12px 32px rgba(0, 0, 0, 0.45);
+  --sys-diagram-head-bg: linear-gradient(90deg, rgba(56, 139, 253, 0.12) 0%, transparent 55%);
+  --sys-diagram-badge-fg: #79c0ff;
+  --sys-diagram-badge-bg: linear-gradient(180deg, #1f2b3d 0%, #1c2128 100%);
+  --sys-diagram-badge-border: #388bfd;
+  --sys-diagram-canvas-bg:
+    radial-gradient(ellipse 90% 60% at 50% 0%, rgba(56, 139, 253, 0.1) 0%, transparent 55%),
+    #0d1117;
+  --sys-diagram-foot-bg: #161b22;
+  --audit-legend-warn-bg: #2d2a1a;
+  --audit-legend-error-bg: #3d2020;
+  --audit-legend-error-fg: #ffb4a8;
+  --badge-default-bg: #1c2128;
+  --badge-success-bg: #14532d;
+  --badge-success-border: #238636;
+  --badge-success-text: #bbf7d0;
+  --badge-warning-bg: #5c4600;
+  --badge-warning-border: #d29922;
+  --badge-warning-text: #ffdf5d;
+  --badge-muted-bg: #21262d;
+  --badge-muted-border: #484f58;
+  --badge-muted-text: #c9d1d9;
+  --badge-danger-bg: #5a1e1e;
+  --badge-danger-border: #da3633;
+  --badge-danger-text: #ffd8d8;
+  --nav-group-bg: linear-gradient(165deg, #161b22 0%, #0d1117 100%);
+  --nav-group-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+  --nav-internal-border: rgba(56, 139, 253, 0.45);
+  --nav-internal-bg: linear-gradient(165deg, #0d1b2a 0%, #0d1117 55%, #161b22 100%);
+  --nav-internal-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  --nav-internal-title: #79c0ff;
+  --nav-internal-hint: #58a6ff;
+  --nav-public-border: rgba(163, 113, 247, 0.45);
+  --nav-public-bg: linear-gradient(165deg, #1a1425 0%, #161b22 55%, #0d1117 100%);
+  --nav-public-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+  --nav-public-title: #d2a8ff;
+  --nav-public-hint: #a371f7;
+  --nav-section-title: #8b949e;
+  --nav-section-hint: #6e7681;
+  --nav-toggle-bg: #161b22;
+  --nav-toggle-fg: #c9d1d9;
+  --nav-toggle-focus-ring: #388bfd;
+  --nav-link-bg: #1c2128;
+  --nav-link-active-bg: #1d2d41;
+  --nav-link-active-border: #388bfd;
+  --nav-link-active-text: #e6edf3;
+  --nav-public-link-hover-border: #a371f7;
+  --nav-public-link-hover-text: #d2a8ff;
+  --nav-public-link-active-bg: #271f3a;
+  --nav-public-link-active-text: #e6d9ff;
+  --nav-pdoc-shell-bg: linear-gradient(180deg, #161b22 0%, rgba(13, 17, 23, 0.5) 100%);
+  --nav-theme-btn-bg: #161b22;
+  --nav-theme-btn-fg: #c9d1d9;
+  --internal-sidebar-title: #8b949e;
+  --internal-tree-border: #30363d;
+  --internal-tree-hover-bg: #1c2d41;
+  --internal-tree-active-bg: #1d2d41;
+  --internal-tree-active-border: #388bfd;
+  --internal-tree-active-text: #e6edf3;
+  --internal-group-bg: #161b22;
+  --internal-summary-hover-bg: #21262d;
+  --internal-http-tablet-bg: linear-gradient(165deg, #161b22 0%, #0d1117 50%, #1a2332 100%);
+  --internal-http-tablet-path: #e6edf3;
+  --internal-toggle-bg: #161b22;
+  --internal-toggle-fg: #c9d1d9;
+  --internal-toggle-hover-fg: #79c0ff;
+  --adr-cs-base-bg: #161b22;
+  --adr-cs-label: #8b949e;
+  --adr-cs-value: #e6edf3;
+  --audit-score-excellent-bg: #1a3d2e;
+  --audit-score-excellent-border: #238636;
+  --audit-score-good-bg: #4d3c00;
+  --audit-score-good-border: #d29922;
+  --audit-score-needs-bg: #5a1e1e;
+  --audit-score-needs-border: #da3633;
+  --audit-score-legend-border: #30363d;
+  --audit-score-legend-bg: #161b22;
+  --status-todo-bg: #1c2d41;
+  --status-todo-border: #484f58;
+  --status-todo-text: #c9d1d9;
+  --status-in-progress-bg: #4d3c00;
+  --status-in-progress-border: #d29922;
+  --status-in-progress-text: #ffdf5d;
+  --status-done-bg: #14532d;
+  --status-done-border: #238636;
+  --status-done-text: #bbf7d0;
+  --status-blocked-bg: #271f3a;
+  --status-blocked-border: #a371f7;
+  --status-blocked-text: #e6d9ff;
+  --status-rejected-bg: #5a1e1e;
+  --status-rejected-border: #da3633;
+  --status-rejected-text: #ffd8d8;
+}
+
+/* ADR “Current status” pill — inner fill + animated rim tuned for dark backgrounds */
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme]) .adr-current-status--draft {
+    background:
+      linear-gradient(#21262d, #21262d) padding-box,
+      conic-gradient(from var(--adr-status-border-angle),
+        #64748b 0deg 65deg,
+        #94a3b8 65deg 180deg,
+        #64748b 180deg 245deg,
+        #94a3b8 245deg 360deg) border-box;
+  }
+
+  html:not([data-theme]) .adr-current-status--ongoing {
+    background:
+      linear-gradient(#3d2f00, #3d2f00) padding-box,
+      conic-gradient(from var(--adr-status-border-angle),
+        #d29922 0deg 65deg,
+        #f0b72d 65deg 180deg,
+        #d29922 180deg 245deg,
+        #f0b72d 245deg 360deg) border-box;
+  }
+
+  html:not([data-theme]) .adr-current-status--declined {
+    background:
+      linear-gradient(#3d2020, #3d2020) padding-box,
+      conic-gradient(from var(--adr-status-border-angle),
+        #da3633 0deg 65deg,
+        #ff7b72 65deg 180deg,
+        #da3633 180deg 245deg,
+        #ff7b72 245deg 360deg) border-box;
+  }
+
+  html:not([data-theme]) .adr-current-status--declined .adr-current-status__value {
+    color: #ffb4a8;
+  }
+
+  html:not([data-theme]) .adr-current-status--done {
+    background:
+      linear-gradient(#14532d, #14532d) padding-box,
+      conic-gradient(from var(--adr-status-border-angle),
+        #238636 0deg 65deg,
+        #56d364 65deg 180deg,
+        #238636 180deg 245deg,
+        #56d364 245deg 360deg) border-box;
+  }
+
+  html:not([data-theme]) .adr-current-status--done .adr-current-status__value {
+    color: #bbf7d0;
+  }
+}
+
+html[data-theme="dark"] .adr-current-status--draft {
+  background:
+    linear-gradient(#21262d, #21262d) padding-box,
+    conic-gradient(from var(--adr-status-border-angle),
+      #64748b 0deg 65deg,
+      #94a3b8 65deg 180deg,
+      #64748b 180deg 245deg,
+      #94a3b8 245deg 360deg) border-box;
+}
+
+html[data-theme="dark"] .adr-current-status--ongoing {
+  background:
+    linear-gradient(#3d2f00, #3d2f00) padding-box,
+    conic-gradient(from var(--adr-status-border-angle),
+      #d29922 0deg 65deg,
+      #f0b72d 65deg 180deg,
+      #d29922 180deg 245deg,
+      #f0b72d 245deg 360deg) border-box;
+}
+
+html[data-theme="dark"] .adr-current-status--declined {
+  background:
+    linear-gradient(#3d2020, #3d2020) padding-box,
+    conic-gradient(from var(--adr-status-border-angle),
+      #da3633 0deg 65deg,
+      #ff7b72 65deg 180deg,
+      #da3633 180deg 245deg,
+      #ff7b72 245deg 360deg) border-box;
+}
+
+html[data-theme="dark"] .adr-current-status--declined .adr-current-status__value {
+  color: #ffb4a8;
+}
+
+html[data-theme="dark"] .adr-current-status--done {
+  background:
+    linear-gradient(#14532d, #14532d) padding-box,
+    conic-gradient(from var(--adr-status-border-angle),
+      #238636 0deg 65deg,
+      #56d364 65deg 180deg,
+      #238636 180deg 245deg,
+      #56d364 245deg 360deg) border-box;
+}
+
+html[data-theme="dark"] .adr-current-status--done .adr-current-status__value {
+  color: #bbf7d0;
+}

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -146,11 +146,20 @@ body {
   line-height: 1.55;
 }
 
+/* Embedded figures / diagrams: never spill past the content column on narrow viewports. */
+img,
+svg,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
 main.container,
 .container {
   max-width: 1080px;
   margin: 0 auto;
   padding: 28px 20px 80px;
+  min-width: 0;
 }
 
 h1,
@@ -262,6 +271,8 @@ pre code {
   padding: 16px 18px;
   margin: 12px 0;
   box-shadow: var(--card-shadow);
+  min-width: 0;
+  max-width: 100%;
 }
 
 .badge {
@@ -414,7 +425,7 @@ p.adr-track-branch-note {
   }
 }
 
-/* ADR: current status + linear status log (docs-nav.js, data-adr-weight on <main>) */
+/* ADR / RFC: current status + linear status log (docs-nav.js: data-adr-weight or data-rfc-weight on <main>) */
 @property --adr-status-border-angle {
   syntax: "<angle>";
   inherits: false;
@@ -548,6 +559,7 @@ p.adr-track-branch-note {
 /* ADR template: collapsible weight instructions (<details> in 0000-template.html) */
 /* docs-theory-help: same chrome for optional “theory background” blocks (e.g. internal README). */
 details.adr-weight-help,
+details.rfc-weight-help,
 details.docs-theory-help {
   margin: 0 0 18px;
   border: 1px solid var(--line);
@@ -557,6 +569,7 @@ details.docs-theory-help {
 }
 
 details.adr-weight-help summary,
+details.rfc-weight-help summary,
 details.docs-theory-help summary {
   cursor: pointer;
   font-weight: 600;
@@ -564,6 +577,7 @@ details.docs-theory-help summary {
 }
 
 details.adr-weight-help[open] summary,
+details.rfc-weight-help[open] summary,
 details.docs-theory-help[open] summary {
   margin-bottom: 8px;
   border-bottom: 1px solid var(--line);
@@ -775,6 +789,38 @@ td {
 th {
   background: var(--table-th-bg);
   font-weight: 600;
+}
+
+/*
+ * Hand-authored docs (`main.container`, not pdoc): keep tables in the content column on narrow viewports.
+ * Skip: .docs-table-scroll (horizontal scroll region), audit score/reference tables (own layout + wrapper).
+ */
+main.container:not(.container--swagger) :not(.docs-table-scroll) > table:not(.audit-ref-table):not(.audit-score-table) {
+  table-layout: fixed;
+  width: 100%;
+  max-width: 100%;
+}
+
+main.container:not(.container--swagger)
+  :not(.docs-table-scroll)
+  > table:not(.audit-ref-table):not(.audit-score-table)
+  th,
+main.container:not(.container--swagger)
+  :not(.docs-table-scroll)
+  > table:not(.audit-ref-table):not(.audit-score-table)
+  td {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+main.container:not(.container--swagger)
+  :not(.docs-table-scroll)
+  > table:not(.audit-ref-table):not(.audit-score-table)
+  :not(pre)
+  > code {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* Assessment Table 2 — score column + legend layout (normative copy: audit-score-legend-fragment.html; ADR 0024). */
@@ -1088,8 +1134,8 @@ main.docs-page-layout [id] {
 /* Back to top — shown when viewport is near the document bottom (see docs-nav.js). */
 .docs-back-to-top {
   position: fixed;
-  right: 1.25rem;
-  bottom: 1.25rem;
+  right: max(1.25rem, env(safe-area-inset-right, 0px));
+  bottom: max(1.25rem, env(safe-area-inset-bottom, 0px));
   z-index: 40;
   width: 44px;
   height: 44px;
@@ -1226,4 +1272,77 @@ main.docs-page-layout [id] {
   line-height: 1.5;
   color: var(--muted);
   max-width: 52rem;
+}
+
+/*
+ * Narrow viewports: comfortable reading width, safe areas (notched phones), slightly smaller type.
+ * Wider layout rules: docs-site-nav.css (720px), .docs-page-layout (960px), ADR tracks (640px).
+ */
+@media (max-width: 520px) {
+  main.container,
+  .container {
+    padding-top: max(20px, env(safe-area-inset-top, 0px));
+    padding-left: max(14px, env(safe-area-inset-left, 0px));
+    padding-right: max(14px, env(safe-area-inset-right, 0px));
+    padding-bottom: max(72px, env(safe-area-inset-bottom, 0px));
+  }
+
+  h1 {
+    font-size: 1.65rem;
+    overflow-wrap: break-word;
+  }
+
+  h2 {
+    font-size: 1.2rem;
+  }
+
+  h3 {
+    font-size: 1rem;
+  }
+
+  .card {
+    padding: 14px 14px;
+    border-radius: 12px;
+  }
+
+  pre {
+    padding: 12px 12px;
+    font-size: 0.85rem;
+  }
+
+  ul,
+  ol {
+    margin-left: 18px;
+  }
+}
+
+@media (max-width: 380px) {
+  h1 {
+    font-size: 1.45rem;
+  }
+}
+
+/* Touch / stylus: larger tap targets; 16px input text avoids iOS zoom-on-focus in Safari. */
+@media (hover: none) and (pointer: coarse) {
+  .docs-search__input {
+    min-height: 44px;
+    font-size: 16px;
+  }
+
+  .top-nav__links a {
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+
+  .top-nav__toggle,
+  .top-nav__theme-btn {
+    min-height: 40px;
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+
+  .docs-inpage-toc nav a {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
 }

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -5,11 +5,124 @@
 :root {
   color-scheme: light;
   --bg: #f7f9fc;
+  --bg-gradient-top: #f4f7fc;
   --card: #ffffff;
   --text: #1f2937;
   --muted: #4b5563;
   --accent: #2563eb;
   --line: #dbe3ef;
+  --inline-code-bg: #eef2ff;
+  --pre-bg: #f1f5f9;
+  --pre-fg: #0f172a;
+  --pre-inset-shadow: rgba(255, 255, 255, 0.6);
+  --table-bg: #ffffff;
+  --table-th-bg: #f3f6fc;
+  --card-shadow: 0 3px 10px rgba(15, 23, 42, 0.05);
+  --search-panel-bg: #ffffff;
+  --search-result-hover-bg: #eff6ff;
+  --search-result-hover-border: #bfdbfe;
+  --search-result-preview: #334155;
+  --docs-placeholder: #94a3b8;
+  --search-results-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+  --time-cell-bg: #f1f5f9;
+  --adr-status-tracks-bg: #fafbff;
+  --adr-track-label-color: #475569;
+  --adr-step-arrow: #94a3b8;
+  --adr-step-border: #cbd5e1;
+  --adr-step-bg: #f1f5f9;
+  --adr-step-text: #475569;
+  --adr-step-done-bg: #dcfce7;
+  --adr-step-done-border: #86efac;
+  --adr-step-done-text: #14532d;
+  --adr-step-current-bg: #fef9c3;
+  --adr-step-current-border: #fde047;
+  --adr-step-current-text: #713f12;
+  --adr-step-todo-bg: #f1f5f9;
+  --adr-step-todo-border: #cbd5e1;
+  --adr-step-todo-text: #64748b;
+  --adr-step-muted-bg: #f1f5f9;
+  --adr-step-muted-border: #cbd5e1;
+  --adr-step-muted-text: #64748b;
+  --adr-step-blocked-bg: #fee2e2;
+  --adr-step-blocked-border: #fca5a5;
+  --adr-step-blocked-text: #7f1d1d;
+  --adr-status-log-bg: #fafbff;
+  --adr-status-log-title: #64748b;
+  --details-summary-fg: #334155;
+  --diagram-bg: #ffffff;
+  --sys-diagram-bg: linear-gradient(165deg, #fafbff 0%, #ffffff 52%);
+  --sys-diagram-frame-shadow:
+    0 1px 0 rgba(15, 23, 42, 0.05),
+    0 12px 32px rgba(15, 23, 42, 0.07);
+  --sys-diagram-head-bg: linear-gradient(90deg, rgba(37, 99, 235, 0.07) 0%, transparent 55%);
+  --sys-diagram-badge-fg: #1e40af;
+  --sys-diagram-badge-bg: linear-gradient(180deg, #dbeafe 0%, #bfdbfe 100%);
+  --sys-diagram-badge-border: #93c5fd;
+  --sys-diagram-canvas-bg:
+    radial-gradient(ellipse 90% 60% at 50% 0%, rgba(37, 99, 235, 0.06) 0%, transparent 55%),
+    #f8fafc;
+  --sys-diagram-foot-bg: #f8fafc;
+  --audit-legend-warn-bg: #fff8e6;
+  --audit-legend-error-bg: #fde8e8;
+  --audit-legend-error-fg: #7f1d1d;
+  --badge-default-bg: #f8fbff;
+  --badge-success-bg: #dcfce7;
+  --badge-success-border: #86efac;
+  --badge-success-text: #14532d;
+  --badge-warning-bg: #fef9c3;
+  --badge-warning-border: #fde047;
+  --badge-warning-text: #713f12;
+  --badge-muted-bg: #f1f5f9;
+  --badge-muted-border: #cbd5e1;
+  --badge-muted-text: #334155;
+  --badge-danger-bg: #fee2e2;
+  --badge-danger-border: #fca5a5;
+  --badge-danger-text: #7f1d1d;
+  /* Top nav (docs-site-nav.css) */
+  --nav-group-bg: linear-gradient(165deg, #ffffff 0%, #f8fafc 100%);
+  --nav-group-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  --nav-internal-border: #bfdbfe;
+  --nav-internal-bg: linear-gradient(165deg, #f8fbff 0%, #f0f7ff 55%, #f8fafc 100%);
+  --nav-internal-shadow: 0 1px 2px rgba(30, 64, 175, 0.05);
+  --nav-internal-title: #1d4ed8;
+  --nav-internal-hint: #60a5fa;
+  --nav-public-border: #e9d5ff;
+  --nav-public-bg: linear-gradient(165deg, #fdfaff 0%, #faf5ff 55%, #f8fafc 100%);
+  --nav-public-shadow: 0 1px 2px rgba(88, 28, 135, 0.05);
+  --nav-public-title: #7e22ce;
+  --nav-public-hint: #a78bfa;
+  --nav-section-title: #64748b;
+  --nav-section-hint: #94a3b8;
+  --nav-toggle-bg: #ffffff;
+  --nav-toggle-fg: #475569;
+  --nav-toggle-focus-ring: #93c5fd;
+  --nav-link-bg: #f8fbff;
+  --nav-link-active-bg: #e8efff;
+  --nav-link-active-border: #9db7ff;
+  --nav-link-active-text: #1e40af;
+  --nav-public-link-hover-border: #c4b5fd;
+  --nav-public-link-hover-text: #7e22ce;
+  --nav-public-link-active-bg: #f5f3ff;
+  --nav-public-link-active-text: #581c87;
+  --nav-pdoc-shell-bg: linear-gradient(180deg, #f8fafc 0%, rgba(248, 250, 252, 0.4) 100%);
+  --nav-theme-btn-bg: #ffffff;
+  --nav-theme-btn-fg: #475569;
+  --internal-sidebar-title: #64748b;
+  --internal-tree-border: #e8edf5;
+  --internal-tree-hover-bg: #eef2ff;
+  --internal-tree-active-bg: #e8efff;
+  --internal-tree-active-border: #c7d7fe;
+  --internal-tree-active-text: #1e40af;
+  --internal-group-bg: #ffffff;
+  --internal-summary-hover-bg: #f8fafc;
+  --internal-http-tablet-bg: linear-gradient(165deg, #ffffff 0%, #f4f7fc 50%, #eef2ff 100%);
+  --internal-http-tablet-path: #0f172a;
+  --internal-toggle-bg: #ffffff;
+  --internal-toggle-fg: #475569;
+  --internal-toggle-hover-fg: #1e40af;
+  --adr-cs-base-bg: #f8fafc;
+  --adr-cs-label: #64748b;
+  --adr-cs-value: #0f172a;
   /* Assessment score bands (Table 2) — see ADR 0024, docs/assets/audit-score-legend-fragment.html */
   --audit-score-excellent-bg: #d1e7dd;
   --audit-score-excellent-border: #198754;
@@ -28,7 +141,7 @@
 body {
   margin: 0;
   font-family: Inter, Segoe UI, Roboto, Arial, sans-serif;
-  background: linear-gradient(180deg, #f4f7fc 0%, var(--bg) 220px);
+  background: linear-gradient(180deg, var(--bg-gradient-top) 0%, var(--bg) 220px);
   color: var(--text);
   line-height: 1.55;
 }
@@ -101,8 +214,8 @@ summary:focus-visible {
 }
 
 /* Inline code only — not inside pre (see pre code below). */
-:not(pre) > code {
-  background: #eef2ff;
+:not(pre)>code {
+  background: var(--inline-code-bg);
   padding: 2px 6px;
   border-radius: 6px;
   font-size: 0.92em;
@@ -116,10 +229,10 @@ pre {
   line-height: 1.5;
   font-size: 0.9rem;
   tab-size: 2;
-  background: #f1f5f9;
-  color: #0f172a;
+  background: var(--pre-bg);
+  color: var(--pre-fg);
   border: 1px solid var(--line);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  box-shadow: inset 0 1px 0 var(--pre-inset-shadow);
 }
 
 /* Avoid nested <code> fighting with pre (was: light box on dark pre → unreadable). */
@@ -148,7 +261,7 @@ pre code {
   border-radius: 14px;
   padding: 16px 18px;
   margin: 12px 0;
-  box-shadow: 0 3px 10px rgba(15, 23, 42, 0.05);
+  box-shadow: var(--card-shadow);
 }
 
 .badge {
@@ -158,32 +271,32 @@ pre code {
   padding: 3px 10px;
   margin: 2px 6px 2px 0;
   font-size: 0.85rem;
-  background: #f8fbff;
+  background: var(--badge-default-bg);
 }
 
 /* ADR and status badges — calm contrast (readable on light background). */
 .badge--success {
-  background: #dcfce7;
-  border-color: #86efac;
-  color: #14532d;
+  background: var(--badge-success-bg);
+  border-color: var(--badge-success-border);
+  color: var(--badge-success-text);
 }
 
 .badge--warning {
-  background: #fef9c3;
-  border-color: #fde047;
-  color: #713f12;
+  background: var(--badge-warning-bg);
+  border-color: var(--badge-warning-border);
+  color: var(--badge-warning-text);
 }
 
 .badge--muted {
-  background: #f1f5f9;
-  border-color: #cbd5e1;
-  color: #334155;
+  background: var(--badge-muted-bg);
+  border-color: var(--badge-muted-border);
+  color: var(--badge-muted-text);
 }
 
 .badge--danger {
-  background: #fee2e2;
-  border-color: #fca5a5;
-  color: #7f1d1d;
+  background: var(--badge-danger-bg);
+  border-color: var(--badge-danger-border);
+  color: var(--badge-danger-text);
 }
 
 .adr-meta {
@@ -200,7 +313,7 @@ pre code {
   padding: 14px 16px;
   border: 1px solid var(--line);
   border-radius: 10px;
-  background: #fafbff;
+  background: var(--adr-status-tracks-bg);
 }
 
 .adr-status-tracks--example {
@@ -223,7 +336,7 @@ p.adr-track-branch-note {
   flex: 0 0 8.5rem;
   font-size: 0.8rem;
   font-weight: 600;
-  color: #475569;
+  color: var(--adr-track-label-color);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -238,16 +351,16 @@ p.adr-track-branch-note {
   margin: 0;
 }
 
-.adr-steps > li {
+.adr-steps>li {
   display: inline-flex;
   align-items: center;
   font-size: 0.85rem;
   line-height: 1.3;
 }
 
-.adr-steps > li + li::before {
+.adr-steps>li+li::before {
   content: "→";
-  color: #94a3b8;
+  color: var(--adr-step-arrow);
   font-size: 0.75rem;
   margin: 0 0.45rem;
   font-weight: normal;
@@ -256,42 +369,42 @@ p.adr-track-branch-note {
 .adr-step {
   border-radius: 8px;
   padding: 4px 10px;
-  border: 1px solid #cbd5e1;
-  background: #f1f5f9;
-  color: #475569;
+  border: 1px solid var(--adr-step-border);
+  background: var(--adr-step-bg);
+  color: var(--adr-step-text);
 }
 
 .adr-step--done {
-  background: #dcfce7;
-  border-color: #86efac;
-  color: #14532d;
+  background: var(--adr-step-done-bg);
+  border-color: var(--adr-step-done-border);
+  color: var(--adr-step-done-text);
 }
 
 .adr-step--current {
-  background: #fef9c3;
-  border-color: #fde047;
-  color: #713f12;
+  background: var(--adr-step-current-bg);
+  border-color: var(--adr-step-current-border);
+  color: var(--adr-step-current-text);
   font-weight: 600;
 }
 
 .adr-step--todo {
-  background: #f1f5f9;
-  border-color: #cbd5e1;
-  color: #64748b;
+  background: var(--adr-step-todo-bg);
+  border-color: var(--adr-step-todo-border);
+  color: var(--adr-step-todo-text);
 }
 
 /* Neutral gray: default “current” for Draft / Not started, or Accepted when Superseded is the final green step. */
 .adr-step--muted {
-  background: #f1f5f9;
-  border-color: #cbd5e1;
-  color: #64748b;
+  background: var(--adr-step-muted-bg);
+  border-color: var(--adr-step-muted-border);
+  color: var(--adr-step-muted-text);
   font-weight: 500;
 }
 
 .adr-step--blocked {
-  background: #fee2e2;
-  border-color: #fca5a5;
-  color: #7f1d1d;
+  background: var(--adr-step-blocked-bg);
+  border-color: var(--adr-step-blocked-border);
+  color: var(--adr-step-blocked-text);
   font-weight: 600;
 }
 
@@ -319,57 +432,51 @@ p.adr-track-branch-note {
   padding: 7px 12px;
   border: 2px solid transparent;
   border-radius: 999px;
-  background: linear-gradient(#f8fafc, #f8fafc) padding-box;
+  background: linear-gradient(var(--adr-cs-base-bg), var(--adr-cs-base-bg)) padding-box;
   position: sticky;
   top: 0;
   z-index: 6;
   font-size: 0.95rem;
-  animation: adr-status-border-sweep 2.8s linear infinite;
+  animation: adr-status-border-sweep 10s linear infinite;
 }
 
 .adr-current-status__label {
-  color: #64748b;
+  color: var(--adr-cs-label);
   margin-right: 0.35em;
 }
 
 .adr-current-status__value {
-  color: #0f172a;
+  color: var(--adr-cs-value);
 }
 
 .adr-current-status--draft {
   background:
     linear-gradient(#f1f5f9, #f1f5f9) padding-box,
-    conic-gradient(
-      from var(--adr-status-border-angle),
+    conic-gradient(from var(--adr-status-border-angle),
       #64748b 0deg 65deg,
       #cbd5e1 65deg 180deg,
       #64748b 180deg 245deg,
-      #cbd5e1 245deg 360deg
-    ) border-box;
+      #cbd5e1 245deg 360deg) border-box;
 }
 
 .adr-current-status--ongoing {
   background:
     linear-gradient(#fffbeb, #fffbeb) padding-box,
-    conic-gradient(
-      from var(--adr-status-border-angle),
+    conic-gradient(from var(--adr-status-border-angle),
       #b45309 0deg 65deg,
       #fcd34d 65deg 180deg,
       #b45309 180deg 245deg,
-      #fcd34d 245deg 360deg
-    ) border-box;
+      #fcd34d 245deg 360deg) border-box;
 }
 
 .adr-current-status--declined {
   background:
     linear-gradient(#fef2f2, #fef2f2) padding-box,
-    conic-gradient(
-      from var(--adr-status-border-angle),
+    conic-gradient(from var(--adr-status-border-angle),
       #b91c1c 0deg 65deg,
       #fca5a5 65deg 180deg,
       #b91c1c 180deg 245deg,
-      #fca5a5 245deg 360deg
-    ) border-box;
+      #fca5a5 245deg 360deg) border-box;
 }
 
 .adr-current-status--declined .adr-current-status__value {
@@ -380,13 +487,11 @@ p.adr-track-branch-note {
 .adr-current-status--done {
   background:
     linear-gradient(#f0fdf4, #f0fdf4) padding-box,
-    conic-gradient(
-      from var(--adr-status-border-angle),
+    conic-gradient(from var(--adr-status-border-angle),
       #15803d 0deg 65deg,
       #86efac 65deg 180deg,
       #15803d 180deg 245deg,
-      #86efac 245deg 360deg
-    ) border-box;
+      #86efac 245deg 360deg) border-box;
 }
 
 .adr-current-status--done .adr-current-status__value {
@@ -411,7 +516,7 @@ p.adr-track-branch-note {
   padding: 12px 14px;
   border: 1px solid var(--line);
   border-radius: 10px;
-  background: #fafbff;
+  background: var(--adr-status-log-bg);
 }
 
 .adr-status-log__title {
@@ -420,7 +525,7 @@ p.adr-track-branch-note {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #64748b;
+  color: var(--adr-status-log-title);
   margin-bottom: 10px;
 }
 
@@ -448,14 +553,14 @@ details.docs-theory-help {
   border: 1px solid var(--line);
   border-radius: 10px;
   padding: 10px 14px 12px;
-  background: #fff;
+  background: var(--card);
 }
 
 details.adr-weight-help summary,
 details.docs-theory-help summary {
   cursor: pointer;
   font-weight: 600;
-  color: #334155;
+  color: var(--details-summary-fg);
 }
 
 details.adr-weight-help[open] summary,
@@ -471,7 +576,7 @@ details.docs-theory-help[open] summary {
   height: auto;
   border: 1px solid var(--line);
   border-radius: 10px;
-  background: #fff;
+  background: var(--diagram-bg);
   padding: 8px;
   margin: 8px 0 6px;
 }
@@ -482,10 +587,8 @@ details.docs-theory-help[open] summary {
   border: 1px solid var(--line);
   border-radius: 14px;
   overflow: hidden;
-  background: linear-gradient(165deg, #fafbff 0%, #ffffff 52%);
-  box-shadow:
-    0 1px 0 rgba(15, 23, 42, 0.05),
-    0 12px 32px rgba(15, 23, 42, 0.07);
+  background: var(--sys-diagram-bg);
+  box-shadow: var(--sys-diagram-frame-shadow);
 }
 
 .sys-diagram__head {
@@ -495,7 +598,7 @@ details.docs-theory-help[open] summary {
   gap: 10px 14px;
   padding: 14px 18px 12px;
   border-bottom: 1px solid var(--line);
-  background: linear-gradient(90deg, rgba(37, 99, 235, 0.07) 0%, transparent 55%);
+  background: var(--sys-diagram-head-bg);
 }
 
 .sys-diagram__badge {
@@ -506,9 +609,9 @@ details.docs-theory-help[open] summary {
   font-weight: 700;
   letter-spacing: 0.07em;
   text-transform: uppercase;
-  color: #1e40af;
-  background: linear-gradient(180deg, #dbeafe 0%, #bfdbfe 100%);
-  border: 1px solid #93c5fd;
+  color: var(--sys-diagram-badge-fg);
+  background: var(--sys-diagram-badge-bg);
+  border: 1px solid var(--sys-diagram-badge-border);
   border-radius: 8px;
   padding: 5px 11px;
 }
@@ -536,9 +639,7 @@ details.docs-theory-help[open] summary {
 .sys-diagram__canvas {
   padding: 22px 14px 26px;
   overflow-x: auto;
-  background:
-    radial-gradient(ellipse 90% 60% at 50% 0%, rgba(37, 99, 235, 0.06) 0%, transparent 55%),
-    #f8fafc;
+  background: var(--sys-diagram-canvas-bg);
 }
 
 .sys-diagram__canvas .mermaid {
@@ -572,7 +673,7 @@ details.docs-theory-help[open] summary {
   font-size: 0.85rem;
   color: var(--muted);
   border-top: 1px solid var(--line);
-  background: #f8fafc;
+  background: var(--sys-diagram-foot-bg);
   line-height: 1.55;
 }
 
@@ -591,7 +692,7 @@ details.docs-theory-help[open] summary {
   margin: 10px 0;
   border-radius: 10px;
   border: 1px solid var(--line);
-  background: #fff;
+  background: var(--table-bg);
 }
 
 .docs-table-scroll table {
@@ -606,7 +707,7 @@ details.docs-theory-help[open] summary {
   border: 1px solid var(--line);
   border-radius: 10px;
   overflow: hidden;
-  background: #fff;
+  background: var(--table-bg);
 }
 
 .api-endpoint {
@@ -656,7 +757,7 @@ table {
   width: 100%;
   border-collapse: collapse;
   margin: 10px 0;
-  background: #fff;
+  background: var(--table-bg);
   border: 1px solid var(--line);
   border-radius: 10px;
   overflow: hidden;
@@ -672,7 +773,7 @@ td {
 }
 
 th {
-  background: #f3f6fc;
+  background: var(--table-th-bg);
   font-weight: 600;
 }
 
@@ -776,14 +877,14 @@ p.audit-score-legend-error {
   padding: 0.65rem 0.85rem;
   font-size: 0.9rem;
   color: var(--muted);
-  background: #fff8e6;
+  background: var(--audit-legend-warn-bg);
   border: 1px solid var(--line);
   border-radius: 6px;
 }
 
 p.audit-score-legend-error {
-  background: #fde8e8;
-  color: #7f1d1d;
+  background: var(--audit-legend-error-bg);
+  color: var(--audit-legend-error-fg);
 }
 
 /* openapi/openapi-explorer.html — OpenAPI (test), Swagger UI browse-only */
@@ -906,22 +1007,22 @@ main.docs-page-layout [id] {
   border-radius: 10px;
   padding: 10px 12px;
   font-size: 0.95rem;
-  background: #fff;
+  background: var(--search-panel-bg);
   color: var(--text);
 }
 
 .docs-search__input::placeholder {
-  color: #94a3b8;
+  color: var(--docs-placeholder);
 }
 
 .docs-search__results {
   list-style: none;
   margin: 8px 0 0;
   padding: 8px;
-  background: #fff;
+  background: var(--search-panel-bg);
   border: 1px solid var(--line);
   border-radius: 10px;
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+  box-shadow: var(--search-results-shadow);
   max-height: 360px;
   overflow-y: auto;
 }
@@ -937,8 +1038,8 @@ main.docs-page-layout [id] {
 
 .docs-search__result-link:hover,
 .docs-search__result-link--active {
-  background: #eff6ff;
-  border-color: #bfdbfe;
+  background: var(--search-result-hover-bg);
+  border-color: var(--search-result-hover-border);
   text-decoration: none;
 }
 
@@ -958,7 +1059,7 @@ main.docs-page-layout [id] {
   display: block;
   margin-top: 4px;
   font-size: 0.85rem;
-  color: #334155;
+  color: var(--search-result-preview);
   line-height: 1.35;
 }
 

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -1084,3 +1084,146 @@ main.docs-page-layout [id] {
     order: 1;
   }
 }
+
+/* Back to top — shown when viewport is near the document bottom (see docs-nav.js). */
+.docs-back-to-top {
+  position: fixed;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  z-index: 40;
+  width: 44px;
+  height: 44px;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--card);
+  color: var(--accent);
+  box-shadow: var(--card-shadow);
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(10px);
+  transition:
+    opacity 0.22s ease,
+    transform 0.22s ease,
+    visibility 0.22s ease;
+}
+
+.docs-back-to-top.docs-back-to-top--visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.docs-back-to-top:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.docs-back-to-top:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* Breadcrumb trail (docs-nav.js) — first child inside #docs-top-nav */
+.docs-breadcrumbs {
+  margin: 0 0 12px;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: var(--muted);
+}
+
+.docs-breadcrumbs__list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem 0.35rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.docs-breadcrumbs__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.docs-breadcrumbs__item + .docs-breadcrumbs__item::before {
+  content: "/";
+  color: var(--line);
+  font-weight: 500;
+  margin-right: 0.15rem;
+  user-select: none;
+}
+
+.docs-breadcrumbs a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.docs-breadcrumbs a:hover {
+  text-decoration: underline;
+}
+
+.docs-breadcrumbs__current {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.docs-breadcrumbs__text {
+  color: var(--muted);
+}
+
+/* Site footer (docs-nav.js initDocsSiteFooter) */
+.docs-site-footer {
+  margin-top: 2.5rem;
+  padding: 1.25rem 0 2rem;
+  border-top: 1px solid var(--line);
+  background: color-mix(in srgb, var(--card) 65%, transparent);
+}
+
+.docs-site-footer__inner {
+  padding-bottom: 0.5rem;
+}
+
+.docs-site-footer__links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0;
+  margin: 0 0 0.65rem;
+  font-size: 0.88rem;
+}
+
+.docs-site-footer__links > a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.docs-site-footer__links > a:hover {
+  text-decoration: underline;
+}
+
+.docs-site-footer__links > a + a::before {
+  content: "·";
+  margin-right: 0.65rem;
+  margin-left: 0.15rem;
+  color: var(--muted);
+  font-weight: 600;
+  pointer-events: none;
+}
+
+.docs-site-footer__meta {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--muted);
+  max-width: 52rem;
+}

--- a/docs/assets/internal-layout.css
+++ b/docs/assets/internal-layout.css
@@ -48,7 +48,7 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #64748b;
+  color: var(--internal-sidebar-title);
   margin: 0 0 10px;
 }
 
@@ -65,26 +65,24 @@
   border: 2px solid transparent;
   border-radius: 999px;
   background:
-    linear-gradient(#ffffff, #ffffff) padding-box,
-    conic-gradient(
-      from var(--internal-toggle-border-angle),
+    linear-gradient(var(--internal-toggle-bg), var(--internal-toggle-bg)) padding-box,
+    conic-gradient(from var(--internal-toggle-border-angle),
       #1d4ed8 0deg 58deg,
       #bfdbfe 58deg 182deg,
       #1d4ed8 182deg 242deg,
-      #bfdbfe 242deg 360deg
-    ) border-box;
-  color: #475569;
+      #bfdbfe 242deg 360deg) border-box;
+  color: var(--internal-toggle-fg);
   font-size: 0.78rem;
   line-height: 1.2;
   padding: 5px 11px;
   cursor: pointer;
   position: relative;
   isolation: isolate;
-  animation: internal-toggle-border-sweep 2.6s linear infinite;
+  animation: internal-toggle-border-sweep 10s linear infinite;
 }
 
 .internal-layout__sidebar-toggle:hover {
-  color: #1e40af;
+  color: var(--internal-toggle-hover-fg);
 }
 
 @keyframes internal-toggle-border-sweep {
@@ -163,10 +161,10 @@
   list-style: none;
   margin: 0;
   padding: 4px 0 6px 12px;
-  border-left: 2px solid #e8edf5;
+  border-left: 2px solid var(--internal-tree-border);
 }
 
-.internal-sidebar__tree > li {
+.internal-sidebar__tree>li {
   margin: 4px 0;
 }
 
@@ -182,22 +180,22 @@
 }
 
 .internal-sidebar__tree a:hover {
-  background: #eef2ff;
+  background: var(--internal-tree-hover-bg);
   text-decoration: none;
 }
 
 .internal-sidebar__tree a.is-active {
-  background: #e8efff;
-  border: 1px solid #c7d7fe;
+  background: var(--internal-tree-active-bg);
+  border: 1px solid var(--internal-tree-active-border);
   font-weight: 650;
-  color: #1e40af;
+  color: var(--internal-tree-active-text);
 }
 
 .internal-sidebar__group {
   margin: 4px 0;
   border: 1px solid var(--line, #dbe3ef);
   border-radius: 10px;
-  background: #fff;
+  background: var(--internal-group-bg);
   overflow: hidden;
 }
 
@@ -233,13 +231,13 @@
   transition: transform 0.12s ease;
 }
 
-.internal-sidebar__group[open] > .internal-sidebar__summary::before {
+.internal-sidebar__group[open]>.internal-sidebar__summary::before {
   transform: rotate(45deg);
   margin-top: -0.1em;
 }
 
 .internal-sidebar__summary:hover {
-  background: #f8fafc;
+  background: var(--internal-summary-hover-bg);
 }
 
 .internal-sidebar__group .internal-sidebar__tree {
@@ -258,7 +256,7 @@
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: #64748b;
+  color: var(--internal-sidebar-title);
 }
 
 h1.internal-doc-h1 {
@@ -277,7 +275,7 @@ h1.internal-doc-h1 {
   padding: 14px 20px;
   border-radius: 16px;
   border: 1px solid var(--line, #dbe3ef);
-  background: linear-gradient(165deg, #ffffff 0%, #f4f7fc 50%, #eef2ff 100%);
+  background: var(--internal-http-tablet-bg);
   box-shadow:
     0 1px 0 rgba(255, 255, 255, 0.85) inset,
     0 6px 22px rgba(15, 23, 42, 0.08);
@@ -304,7 +302,7 @@ h1.internal-doc-h1 {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 0.9rem;
   line-height: 1.45;
-  color: #0f172a;
+  color: var(--internal-http-tablet-path);
   word-break: break-all;
 }
 

--- a/docs/audit/2026-04-14-api-assessment.html
+++ b/docs/audit/2026-04-14-api-assessment.html
@@ -1,10 +1,13 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>REST API Assessment — Study App (14 Apr 2026)</title>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
 </head>
 

--- a/docs/audit/2026-04-14-documentation-experience-assessment.html
+++ b/docs/audit/2026-04-14-documentation-experience-assessment.html
@@ -1,10 +1,13 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Documentation Experience (DX) Assessment — Study App (14 Apr 2026)</title>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
 </head>
 

--- a/docs/audit/2026-04-17-documentation-experience-world-class-gap-assessment.html
+++ b/docs/audit/2026-04-17-documentation-experience-world-class-gap-assessment.html
@@ -1,10 +1,13 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Documentation Experience Assessment Update — World-Class Gap Check (17 Apr 2026)</title>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
 </head>
 

--- a/docs/audit/README.html
+++ b/docs/audit/README.html
@@ -1,10 +1,13 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Architecture &amp; quality assessments — index</title>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
 </head>
 

--- a/docs/audit/README.html
+++ b/docs/audit/README.html
@@ -60,29 +60,25 @@
               <th scope="col">Assessment</th>
               <th scope="col">Date</th>
               <th scope="col">Focus</th>
-              <th scope="col">Open</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td>REST API assessment</td>
+              <td><a href="./2026-04-14-api-assessment.html">REST API assessment</a></td>
               <td>2026-04-14</td>
               <td>HTTP API, OpenAPI governance, idempotency, security headers, observability hooks, CI contract checks.
               </td>
-              <td><a href="./2026-04-14-api-assessment.html">Open</a></td>
             </tr>
             <tr>
-              <td>Documentation Experience (DX) assessment</td>
+              <td><a href="./2026-04-14-documentation-experience-assessment.html">Documentation Experience (DX) assessment</a></td>
               <td>2026-04-14</td>
               <td>Information architecture, docs-as-code, discovery, API docs UX, accessibility, feedback, and related DX
                 themes.</td>
-                <td><a href="./2026-04-14-documentation-experience-assessment.html">Open</a></td>
               </tr>
               <tr>
-                <td>Documentation Experience (DX) world-class gap check</td>
+                <td><a href="./2026-04-17-documentation-experience-world-class-gap-assessment.html">Documentation Experience (DX) world-class gap check</a></td>
                 <td>2026-04-17</td>
                 <td>Re-check against top-tier documentation standards with explicit design-maturity and closure plan focus.</td>
-                <td><a href="./2026-04-17-documentation-experience-world-class-gap-assessment.html">Open</a></td>
               </tr>
             </tbody>
           </table>

--- a/docs/backlog/README.html
+++ b/docs/backlog/README.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Backlog — quality and scale roadmap</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <link rel="stylesheet" href="backlog.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">

--- a/docs/backlog/backlog.css
+++ b/docs/backlog/backlog.css
@@ -146,7 +146,7 @@
 
 .time-cell {
   padding: 10px 12px;
-  background: #f1f5f9;
+  background: var(--time-cell-bg);
   border-radius: 8px;
   font-size: 0.9rem;
 }

--- a/docs/developer/0001-requirements.html
+++ b/docs/developer/0001-requirements.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Developer Requirements Guide</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/developer/0002-schemas-and-contracts.html
+++ b/docs/developer/0002-schemas-and-contracts.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Schemas and Contracts Guide</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/developer/0003-business-logic.html
+++ b/docs/developer/0003-business-logic.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Business Logic Guide</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/developer/0004-how-to-add-post-contract.html
+++ b/docs/developer/0004-how-to-add-post-contract.html
@@ -1,11 +1,14 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Moved — POST /api/v1/contract guide</title>
   <meta http-equiv="refresh" content="0; url=../howto/0004-how-to-add-post-contract.html">
   <link rel="canonical" href="../howto/0004-how-to-add-post-contract.html">
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/developer/0005-error-matrix-by-status.html
+++ b/docs/developer/0005-error-matrix-by-status.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Error Matrix By Status</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/developer/0006-api-load-testing.html
+++ b/docs/developer/0006-api-load-testing.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>API load testing (step-by-step)</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/developer/0007-local-development.html
+++ b/docs/developer/0007-local-development.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Local development (environment and run targets)</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/developer/0008-docs-pipeline.html
+++ b/docs/developer/0008-docs-pipeline.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Documentation pipeline (docs-as-code)</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/developer/0009-docker-and-kubernetes-local.html
+++ b/docs/developer/0009-docker-and-kubernetes-local.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Docker image and local Kubernetes</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/developer/0010-make-commands-and-workflows.html
+++ b/docs/developer/0010-make-commands-and-workflows.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Make commands and workflows (onboarding)</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/developer/README.html
+++ b/docs/developer/README.html
@@ -1,11 +1,14 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Moved — Developers Docs</title>
   <meta http-equiv="refresh" content="0; url=../internal/developers.html#developer-guides-index">
   <link rel="canonical" href="../internal/developers.html">
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/howto/0004-how-to-add-post-contract.html
+++ b/docs/howto/0004-how-to-add-post-contract.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Guide For Beginners: Add `POST /api/v1/contract`</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/howto/README.html
+++ b/docs/howto/README.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>How-to guides — Study App</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/howto/README.html
+++ b/docs/howto/README.html
@@ -94,24 +94,20 @@
           <tr>
             <th>Guide</th>
             <th>When to use it</th>
-            <th>Open</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>Onboarding: from zero to endpoint and docs</td>
+            <td><a href="./onboarding-from-zero-to-endpoint-docs.html">Onboarding: from zero to endpoint and docs</a></td>
             <td>First contribution path; full lifecycle from setup to quality gates.</td>
-            <td><a href="./onboarding-from-zero-to-endpoint-docs.html">Open guide</a></td>
           </tr>
           <tr>
-            <td>Internal service docs layout and how to add pages</td>
+            <td><a href="./internal-service-docs-layout.html">Internal service docs layout and how to add pages</a></td>
             <td>Add/update pages under <code>docs/internal/</code>, sidebar navigation, and internal API docs layout.</td>
-            <td><a href="./internal-service-docs-layout.html">Open guide</a></td>
           </tr>
           <tr>
-            <td>Beginner walkthrough: add <code>POST /api/v1/contract</code></td>
+            <td><a href="./0004-how-to-add-post-contract.html">Beginner walkthrough: add <code>POST /api/v1/contract</code></a></td>
             <td>Concrete endpoint implementation example through all service layers.</td>
-            <td><a href="./0004-how-to-add-post-contract.html">Open guide</a></td>
           </tr>
         </tbody>
       </table>

--- a/docs/howto/internal-service-docs-layout.html
+++ b/docs/howto/internal-service-docs-layout.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Internal service docs — layout and how to add pages</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/howto/onboarding-from-zero-to-endpoint-docs.html
+++ b/docs/howto/onboarding-from-zero-to-endpoint-docs.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Onboarding: from zero to endpoint and docs — Study App</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,10 +1,13 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ETR (Extract–Transform–Retrieve) Study API — Documentation</title>
   <link rel="icon" type="image/svg+xml" href="./assets/favicon.svg">
   <link rel="stylesheet" href="./assets/docs.css" />
+  <link rel="stylesheet" href="./assets/docs-theme.css">
   <script defer src="./assets/docs-nav.js"></script>
 </head>
 

--- a/docs/internal/README.html
+++ b/docs/internal/README.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Welcome — Internal docs — Study App</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <link rel="stylesheet" href="../assets/internal-layout.css">
   <script defer src="../assets/docs-nav.js"></script>
   <script defer src="../assets/internal-sidebar.js"></script>

--- a/docs/internal/api/README.html
+++ b/docs/internal/api/README.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>HTTP API — internal documentation hub — Study App</title>
   <link rel="stylesheet" href="../../assets/docs.css" />
+  <link rel="stylesheet" href="../../assets/docs-theme.css">
   <link rel="stylesheet" href="../../assets/internal-layout.css">
   <script defer src="../../assets/docs-nav.js"></script>
   <script defer src="../../assets/internal-sidebar.js"></script>

--- a/docs/internal/api/errors.html
+++ b/docs/internal/api/errors.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Error catalog and sync — Study App</title>
   <link rel="stylesheet" href="../../assets/docs.css" />
+  <link rel="stylesheet" href="../../assets/docs-theme.css">
   <link rel="stylesheet" href="../../assets/internal-layout.css">
   <script defer src="../../assets/docs-nav.js"></script>
   <script defer src="../../assets/internal-sidebar.js"></script>

--- a/docs/internal/api/user/index.html
+++ b/docs/internal/api/user/index.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>User resource — internal specification — Study App</title>
   <link rel="stylesheet" href="../../../assets/docs.css" />
+  <link rel="stylesheet" href="../../../assets/docs-theme.css">
   <link rel="stylesheet" href="../../../assets/internal-layout.css">
   <script defer src="../../../assets/docs-nav.js"></script>
   <script defer src="../../../assets/internal-sidebar.js"></script>

--- a/docs/internal/api/user/operations/get-api-v1-user-system_uuid-system_user_id.html
+++ b/docs/internal/api/user/operations/get-api-v1-user-system_uuid-system_user_id.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>GET /api/v1/user/{system_uuid}/{system_user_id} — User — Study App</title>
   <link rel="stylesheet" href="../../../../assets/docs.css" />
+  <link rel="stylesheet" href="../../../../assets/docs-theme.css">
   <link rel="stylesheet" href="../../../../assets/internal-layout.css">
   <script defer src="../../../../assets/docs-nav.js"></script>
   <script defer src="../../../../assets/internal-sidebar.js"></script>

--- a/docs/internal/api/user/operations/patch-api-v1-user-system_uuid-system_user_id.html
+++ b/docs/internal/api/user/operations/patch-api-v1-user-system_uuid-system_user_id.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>PATCH /api/v1/user/{system_uuid}/{system_user_id} — User — Study App</title>
   <link rel="stylesheet" href="../../../../assets/docs.css" />
+  <link rel="stylesheet" href="../../../../assets/docs-theme.css">
   <link rel="stylesheet" href="../../../../assets/internal-layout.css">
   <script defer src="../../../../assets/docs-nav.js"></script>
   <script defer src="../../../../assets/internal-sidebar.js"></script>

--- a/docs/internal/api/user/operations/post-api-v1-user.html
+++ b/docs/internal/api/user/operations/post-api-v1-user.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>POST /api/v1/user — User — Study App</title>
   <link rel="stylesheet" href="../../../../assets/docs.css" />
+  <link rel="stylesheet" href="../../../../assets/docs-theme.css">
   <link rel="stylesheet" href="../../../../assets/internal-layout.css">
   <script defer src="../../../../assets/docs-nav.js"></script>
   <script defer src="../../../../assets/internal-sidebar.js"></script>

--- a/docs/internal/api/user/operations/put-api-v1-user-system_uuid-system_user_id.html
+++ b/docs/internal/api/user/operations/put-api-v1-user-system_uuid-system_user_id.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>PUT /api/v1/user/{system_uuid}/{system_user_id} — User — Study App</title>
   <link rel="stylesheet" href="../../../../assets/docs.css" />
+  <link rel="stylesheet" href="../../../../assets/docs-theme.css">
   <link rel="stylesheet" href="../../../../assets/internal-layout.css">
   <script defer src="../../../../assets/docs-nav.js"></script>
   <script defer src="../../../../assets/internal-sidebar.js"></script>

--- a/docs/internal/api/user/user-http-api.html
+++ b/docs/internal/api/user/user-http-api.html
@@ -1,5 +1,7 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Moved — User resource</title>
@@ -11,6 +13,7 @@
     })();
   </script>
   <link rel="stylesheet" href="../../../assets/docs.css" />
+  <link rel="stylesheet" href="../../../assets/docs-theme.css">
   <script defer src="../../../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../../../assets/favicon.svg">
 </head>

--- a/docs/internal/developers.html
+++ b/docs/internal/developers.html
@@ -106,29 +106,24 @@
               <tr>
                 <th>Guide</th>
                 <th>Description</th>
-                <th>Open</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td>Requirements guide</td>
+                <td><a href="../developer/0001-requirements.html">Requirements guide</a></td>
                 <td>Functional and non-functional requirements interpretation for developers.</td>
-                <td><a href="../developer/0001-requirements.html">Open</a></td>
               </tr>
               <tr>
-                <td>Schemas and contracts</td>
+                <td><a href="../developer/0002-schemas-and-contracts.html">Schemas and contracts</a></td>
                 <td>Safe request/response/error evolution rules.</td>
-                <td><a href="../developer/0002-schemas-and-contracts.html">Open</a></td>
               </tr>
               <tr>
-                <td>Business logic guide</td>
+                <td><a href="../developer/0003-business-logic.html">Business logic guide</a></td>
                 <td>Layer boundaries, processing order, and service responsibilities.</td>
-                <td><a href="../developer/0003-business-logic.html">Open</a></td>
               </tr>
               <tr>
-                <td>Error matrix by status</td>
+                <td><a href="../developer/0005-error-matrix-by-status.html">Error matrix by status</a></td>
                 <td>COMMON vs domain-specific error contracts.</td>
-                <td><a href="../developer/0005-error-matrix-by-status.html">Open</a></td>
               </tr>
             </tbody>
           </table>
@@ -139,39 +134,32 @@
               <tr>
                 <th>Guide</th>
                 <th>Description</th>
-                <th>Open</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td>Make commands and workflows</td>
+                <td><a href="../developer/0010-make-commands-and-workflows.html">Make commands and workflows</a></td>
                 <td>Canonical quality gates and grouped commands.</td>
-                <td><a href="../developer/0010-make-commands-and-workflows.html">Open</a></td>
               </tr>
               <tr>
-                <td>Make commands reference (internal)</td>
+                <td><a href="./make-commands.html">Make commands reference (internal)</a></td>
                 <td>Project command catalog with workflows and full `Makefile` inventory.</td>
-                <td><a href="./make-commands.html">Open</a></td>
               </tr>
               <tr>
-                <td>Local development</td>
+                <td><a href="../developer/0007-local-development.html">Local development</a></td>
                 <td>Runtime setup, ports, observability stack, and daily loop.</td>
-                <td><a href="../developer/0007-local-development.html">Open</a></td>
               </tr>
               <tr>
-                <td>Docker and local Kubernetes</td>
+                <td><a href="../developer/0009-docker-and-kubernetes-local.html">Docker and local Kubernetes</a></td>
                 <td>Image build, manifests, and local cluster workflow.</td>
-                <td><a href="../developer/0009-docker-and-kubernetes-local.html">Open</a></td>
               </tr>
               <tr>
-                <td>API load testing</td>
+                <td><a href="../developer/0006-api-load-testing.html">API load testing</a></td>
                 <td>Load-test scenarios and local execution workflow.</td>
-                <td><a href="../developer/0006-api-load-testing.html">Open</a></td>
               </tr>
               <tr>
-                <td>Documentation pipeline</td>
+                <td><a href="../developer/0008-docs-pipeline.html">Documentation pipeline</a></td>
                 <td>How <code>docs-fix</code>, generated docs, and sync checks work.</td>
-                <td><a href="../developer/0008-docs-pipeline.html">Open</a></td>
               </tr>
             </tbody>
           </table>
@@ -182,24 +170,20 @@
               <tr>
                 <th>Guide</th>
                 <th>Description</th>
-                <th>Open</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td>Beginner endpoint guide</td>
+                <td><a href="../howto/0004-how-to-add-post-contract.html">Beginner endpoint guide</a></td>
                 <td>Step-by-step endpoint implementation example.</td>
-                <td><a href="../howto/0004-how-to-add-post-contract.html">Open</a></td>
               </tr>
               <tr>
-                <td>Python docstrings and pdoc</td>
+                <td><a href="../adr/0016-python-docstrings-google-style-and-pdoc.html">Python docstrings and pdoc</a></td>
                 <td>Contributor rules for API docs generation.</td>
-                <td><a href="../adr/0016-python-docstrings-google-style-and-pdoc.html">ADR 0016</a></td>
               </tr>
               <tr>
-                <td>Branches and repository workflow</td>
+                <td><a href="../adr/0017-branch-naming-and-repository-workflow.html">Branches and repository workflow</a></td>
                 <td>Branch naming, trunk strategy, releases, and hotfix flow.</td>
-                <td><a href="../adr/0017-branch-naming-and-repository-workflow.html">ADR 0017</a></td>
               </tr>
             </tbody>
           </table>

--- a/docs/internal/developers.html
+++ b/docs/internal/developers.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Developers Docs — Study App</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <link rel="stylesheet" href="../assets/internal-layout.css">
   <script defer src="../assets/docs-nav.js"></script>
   <script defer src="../assets/internal-sidebar.js"></script>

--- a/docs/internal/documentation-style-guide.html
+++ b/docs/internal/documentation-style-guide.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Documentation style guide and audit standard</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <link rel="stylesheet" href="../assets/internal-layout.css">
   <script defer src="../assets/docs-nav.js"></script>
   <script defer src="../assets/internal-sidebar.js"></script>

--- a/docs/internal/errors.html
+++ b/docs/internal/errors.html
@@ -1,10 +1,13 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=./api/errors.html">
   <link rel="canonical" href="./api/errors.html">
   <title>Moved: Error catalog</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/internal/make-commands.html
+++ b/docs/internal/make-commands.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Make commands — Internal docs — Study App</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <link rel="stylesheet" href="../assets/internal-layout.css">
   <script defer src="../assets/docs-nav.js"></script>
   <script defer src="../assets/internal-sidebar.js"></script>

--- a/docs/internal/methodology.html
+++ b/docs/internal/methodology.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Methodology (ETR / Extract–Transform–Retrieve, idea discovery) — Study App</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <link rel="stylesheet" href="../assets/internal-layout.css">
   <script defer src="../assets/docs-nav.js"></script>
   <script defer src="../assets/internal-sidebar.js"></script>

--- a/docs/internal/service-overview.html
+++ b/docs/internal/service-overview.html
@@ -1,11 +1,14 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Moved — Internal service documentation</title>
   <meta http-equiv="refresh" content="0; url=README.html">
   <link rel="canonical" href="README.html">
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/internal/system-analysis.html
+++ b/docs/internal/system-analysis.html
@@ -1,11 +1,14 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Moved — System design</title>
   <meta http-equiv="refresh" content="0; url=system-design.html">
   <link rel="canonical" href="system-design.html">
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/internal/system-design.html
+++ b/docs/internal/system-design.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ETR (Extract–Transform–Retrieve) Study API — System design</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <link rel="stylesheet" href="../assets/internal-layout.css">
   <script defer src="../assets/docs-nav.js"></script>
   <script defer src="../assets/internal-sidebar.js"></script>

--- a/docs/internal/system-design.html
+++ b/docs/internal/system-design.html
@@ -390,19 +390,16 @@
                                               <tr>
                                                 <th>Document</th>
                                                 <th>Description</th>
-                                                <th>Open</th>
                                               </tr>
                                             </thead>
                                             <tbody>
                                               <tr>
-                                                <td>ADR Index</td>
+                                                <td><a href="../adr/README.html">ADR Index</a></td>
                                                 <td>All architecture decisions, their rationale, and reference links.</td>
-                                                <td><a href="../adr/README.html">Open ADR index</a></td>
                                               </tr>
                                               <tr>
-                                                <td>ADR Template</td>
+                                                <td><a href="../adr/0000-template.html">ADR Template</a></td>
                                                 <td>Template for creating a new ADR with required sections and structure.</td>
-                                                <td><a href="../adr/0000-template.html">Open template</a></td>
                                               </tr>
                                             </tbody>
                                           </table>
@@ -418,16 +415,14 @@
                                               <tr>
                                                 <th>Document</th>
                                                 <th>Description</th>
-                                                <th>Open</th>
                                               </tr>
                                             </thead>
                                             <tbody>
                                               <tr>
-                                                <td>Developers Docs</td>
+                                                <td><a href="./developers.html">Developers Docs</a></td>
                                                 <td>Engineering workflow, quality gates, policies, and index of guides under
                                                   <code>docs/developer/</code>.
                                                 </td>
-                                                <td><a href="./developers.html">Open document</a></td>
                                               </tr>
                                             </tbody>
                                           </table>

--- a/docs/openapi/openapi-explorer.html
+++ b/docs/openapi/openapi-explorer.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Study App API — OpenAPI (test)</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.18.2/swagger-ui.min.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">

--- a/docs/rfc/0001-docs-search-implementation.html
+++ b/docs/rfc/0001-docs-search-implementation.html
@@ -12,13 +12,13 @@
 </head>
 
 <body>
-  <main class="container">
+  <main class="container" data-rfc-weight="7">
     <h1>RFC 0001: Documentation Search Implementation</h1>
     <div id="docs-top-nav"></div>
+    <details class="rfc-weight-help" data-docs-lifecycle="rfc-short"></details>
     <section class="card">
-      <h2>Status</h2>
+      <h2>Metadata</h2>
       <ul>
-        <li>State: active</li>
         <li>Date: 2026-04-17</li>
         <li>Related decision: <a href="../adr/0027-client-side-docs-search-index-and-ranking.html">ADR 0027</a></li>
       </ul>

--- a/docs/rfc/0001-docs-search-implementation.html
+++ b/docs/rfc/0001-docs-search-implementation.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>RFC 0001: Documentation Search Implementation</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/rfc/0002-docs-search-kpi-policy-and-slo.html
+++ b/docs/rfc/0002-docs-search-kpi-policy-and-slo.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>RFC 0002: Docs Search KPI Policy and SLO Thresholds</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/rfc/0002-docs-search-kpi-policy-and-slo.html
+++ b/docs/rfc/0002-docs-search-kpi-policy-and-slo.html
@@ -12,13 +12,13 @@
 </head>
 
 <body>
-  <main class="container">
+  <main class="container" data-rfc-weight="7">
     <h1>RFC 0002: Docs Search KPI Policy and SLO Thresholds</h1>
     <div id="docs-top-nav"></div>
+    <details class="rfc-weight-help" data-docs-lifecycle="rfc-short"></details>
     <section class="card">
-      <h2>Status</h2>
+      <h2>Metadata</h2>
       <ul>
-        <li>State: active</li>
         <li>Date: 2026-04-17</li>
         <li>Related decision: <a href="../adr/0027-client-side-docs-search-index-and-ranking.html">ADR 0027</a></li>
         <li>Related implementation: <a href="./0001-docs-search-implementation.html">RFC 0001</a></li>

--- a/docs/rfc/README.html
+++ b/docs/rfc/README.html
@@ -18,6 +18,9 @@
     <p class="lead">
       RFC documents capture implementation-level technical details and operational playbooks.
       ADRs describe decisions and rationale; RFCs describe concrete realization and maintenance.
+      Each numbered RFC page sets <code>data-rfc-weight</code> on <code>&lt;main&gt;</code> (−1…7) so
+      <strong>Current status</strong> and the <strong>Status log</strong> match the same lifecycle model as ADRs
+      (<a href="../adr/0018-adr-lifecycle-ratification-and-badges.html">ADR 0018</a>).
     </p>
     <section class="card">
       <h2>Available RFCs</h2>
@@ -26,19 +29,16 @@
           <tr>
             <th>Document</th>
             <th>Description</th>
-            <th>Open</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>RFC 0001</td>
-            <td>Documentation search implementation: index model, ranking, telemetry pipeline, storage, and validation.</td>
             <td><a href="./0001-docs-search-implementation.html">RFC 0001</a></td>
+            <td>Documentation search implementation: index model, ranking, telemetry pipeline, storage, and validation.</td>
           </tr>
           <tr>
-            <td>RFC 0002</td>
-            <td>Docs search KPI policy: SLO targets, warning/breach thresholds, and operational response playbook.</td>
             <td><a href="./0002-docs-search-kpi-policy-and-slo.html">RFC 0002</a></td>
+            <td>Docs search KPI policy: SLO targets, warning/breach thresholds, and operational response playbook.</td>
           </tr>
         </tbody>
       </table>

--- a/docs/rfc/README.html
+++ b/docs/rfc/README.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>RFC Index</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/runbooks/0000-template.html
+++ b/docs/runbooks/0000-template.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Runbook: &lt;incident-name&gt;</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/runbooks/0001-tests-failing.html
+++ b/docs/runbooks/0001-tests-failing.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Runbook: Tests Failing</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/runbooks/0002-migrations-failing.html
+++ b/docs/runbooks/0002-migrations-failing.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Runbook: Migrations Failing</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/runbooks/0003-logging-failing.html
+++ b/docs/runbooks/0003-logging-failing.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Runbook: Logging Failing</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/runbooks/0004-pre-commit-failing.html
+++ b/docs/runbooks/0004-pre-commit-failing.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Runbook: Pre-commit Failing</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/runbooks/0005-quality-check-failing.html
+++ b/docs/runbooks/0005-quality-check-failing.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Runbook: Quality Check Failing</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/runbooks/0006-api-security-failing.html
+++ b/docs/runbooks/0006-api-security-failing.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Runbook: API Security Failing</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/runbooks/0007-openapi-contract-test-failing.html
+++ b/docs/runbooks/0007-openapi-contract-test-failing.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Runbook: OpenAPI Contract-Test Failing</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/runbooks/0008-observability-scrape-failing.html
+++ b/docs/runbooks/0008-observability-scrape-failing.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Runbook: Observability Scrape Failing</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/runbooks/0009-error-budget-exhaustion.html
+++ b/docs/runbooks/0009-error-budget-exhaustion.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Runbook: Error Budget Exhaustion and SLO Alerts</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/runbooks/0010-in-page-toc-missing.html
+++ b/docs/runbooks/0010-in-page-toc-missing.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Runbook: In-page “On this page” sidebar missing or empty</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/runbooks/README.html
+++ b/docs/runbooks/README.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head>
+  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Runbooks Index</title>
   <link rel="stylesheet" href="../assets/docs.css" />
+  <link rel="stylesheet" href="../assets/docs-theme.css">
   <script defer src="../assets/docs-nav.js"></script>
   <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 </head>

--- a/docs/runbooks/README.html
+++ b/docs/runbooks/README.html
@@ -31,65 +31,53 @@
           <tr>
             <th>Document</th>
             <th>Description</th>
-            <th>Open</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>Template</td>
+            <td><a href="./0000-template.html">Template</a></td>
             <td>Template for creating a new runbook with consistent incident structure.</td>
-            <td><a href="./0000-template.html">Open template</a></td>
           </tr>
           <tr>
-            <td>Tests failing</td>
+            <td><a href="./0001-tests-failing.html">Tests failing</a></td>
             <td>Triage and recovery flow for failing automated tests.</td>
-            <td><a href="./0001-tests-failing.html">Open runbook</a></td>
           </tr>
           <tr>
-            <td>Migrations failing</td>
+            <td><a href="./0002-migrations-failing.html">Migrations failing</a></td>
             <td>Recovery steps for migration generation/apply issues and schema mismatch.</td>
-            <td><a href="./0002-migrations-failing.html">Open runbook</a></td>
           </tr>
           <tr>
-            <td>Logging failing</td>
+            <td><a href="./0003-logging-failing.html">Logging failing</a></td>
             <td>Diagnostics for log setup, paths, permissions, and runtime logging behavior.</td>
-            <td><a href="./0003-logging-failing.html">Open runbook</a></td>
           </tr>
           <tr>
-            <td>Pre-commit failing</td>
+            <td><a href="./0004-pre-commit-failing.html">Pre-commit failing</a></td>
             <td>Fix path for hook failures and staged/unstaged formatting conflicts.</td>
-            <td><a href="./0004-pre-commit-failing.html">Open runbook</a></td>
           </tr>
           <tr>
-            <td>Quality check failing</td>
+            <td><a href="./0005-quality-check-failing.html">Quality check failing</a></td>
             <td>Step-by-step breakdown for lint, type-check, test, and docs gate failures.</td>
-            <td><a href="./0005-quality-check-failing.html">Open runbook</a></td>
           </tr>
           <tr>
-            <td>API security failing</td>
+            <td><a href="./0006-api-security-failing.html">API security failing</a></td>
             <td>Triage and recovery for auth, rate-limit, CORS, security headers, and body-size constraints.</td>
-            <td><a href="./0006-api-security-failing.html">Open runbook</a></td>
           </tr>
           <tr>
-            <td>OpenAPI contract test failing</td>
+            <td><a href="./0007-openapi-contract-test-failing.html">OpenAPI contract test failing</a></td>
             <td>Recovery flow for OpenAPI snapshot drift and baseline update decisions.</td>
-            <td><a href="./0007-openapi-contract-test-failing.html">Open runbook</a></td>
           </tr>
           <tr>
-            <td>Observability scrape failing</td>
+            <td><a href="./0008-observability-scrape-failing.html">Observability scrape failing</a></td>
             <td>Triage and recovery for Prometheus scrape failures and empty Grafana dashboards.</td>
-            <td><a href="./0008-observability-scrape-failing.html">Open runbook</a></td>
           </tr>
           <tr>
-            <td>Error budget exhaustion</td>
+            <td><a href="./0009-error-budget-exhaustion.html">Error budget exhaustion</a></td>
             <td>Response when SLO error budget is burned, Prometheus SLO alerts fire, or readiness/latency targets
               break.</td>
-              <td><a href="./0009-error-budget-exhaustion.html">Open runbook</a></td>
             </tr>
             <tr>
-              <td>In-page TOC missing</td>
+              <td><a href="./0010-in-page-toc-missing.html">In-page TOC missing</a></td>
               <td>“On this page” sidebar absent, empty, or wrong; mount, headings, or script troubleshooting.</td>
-              <td><a href="./0010-in-page-toc-missing.html">Open runbook</a></td>
             </tr>
           </tbody>
         </table>

--- a/scripts/inject_docs_theme_assets.py
+++ b/scripts/inject_docs_theme_assets.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Insert docs-theme.css and early theme script into hand-written docs HTML pages."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+
+THEME_MARKER = "docs-theme.css"
+SCRIPT_MARKER = "docs-theme-preference"
+
+EARLY_SCRIPT = """  <script>(function(){try{var k="docs-theme-preference",v=localStorage.getItem(k);if(v==="dark")document.documentElement.setAttribute("data-theme","dark");else if(v==="light")document.documentElement.setAttribute("data-theme","light");}catch(e){}})();</script>
+"""
+
+
+def _theme_href(html_path: Path) -> str:
+    """Return the relative href to ``docs-theme.css`` from a file under ``docs/``."""
+    rel = html_path.relative_to(DOCS)
+    depth = len(rel.parts) - 1
+    if depth == 0:
+        return "./assets/docs-theme.css"
+    return f"{'../' * depth}assets/docs-theme.css"
+
+
+def _inject_theme_link(lines: list[str], html_path: Path) -> tuple[list[str], bool]:
+    """Insert a ``docs-theme.css`` link after the first ``docs.css`` link if missing."""
+    if any(THEME_MARKER in line for line in lines):
+        return lines, False
+    href = _theme_href(html_path)
+    out: list[str] = []
+    inserted = False
+    for line in lines:
+        out.append(line)
+        if inserted:
+            continue
+        if "docs.css" in line and "href=" in line and "docs-theme" not in line:
+            li = line[: len(line) - len(line.lstrip())]
+            out.append(f'{li}<link rel="stylesheet" href="{href}" />\n')
+            inserted = True
+    return out, inserted
+
+
+def _inject_early_script(text: str) -> tuple[str, bool]:
+    """Insert a synchronous script that applies stored theme before first paint."""
+    if SCRIPT_MARKER in text:
+        return text, False
+    if "<head>" not in text:
+        return text, False
+    return text.replace("<head>", "<head>\n" + EARLY_SCRIPT, 1), True
+
+
+def main() -> int:
+    """Walk ``docs/**/*.html``, patch pages that reference ``docs.css``.
+
+    Returns:
+        Process exit code (always 0).
+    """
+    changed = 0
+    for path in sorted(DOCS.rglob("*.html")):
+        raw = path.read_text(encoding="utf-8")
+        if "docs.css" not in raw:
+            continue
+        lines = raw.splitlines(keepends=True)
+        lines, did_link = _inject_theme_link(lines, path)
+        text = "".join(lines)
+        text, did_script = _inject_early_script(text)
+        if did_link or did_script:
+            path.write_text(text, encoding="utf-8")
+            changed += 1
+    if changed:
+        print(f"Updated {changed} file(s) with docs theme assets.")
+    else:
+        print("No files needed updates (already injected or no docs.css).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- **Single source for lifecycle help:** Repeated `<details>` text for `data-adr-weight` / `data-rfc-weight` is no longer duplicated across ADR/RFC HTML. It is injected from `docs/assets/docs-nav.js` (`injectDocsLifecycleHelp`, versioned via `DOCS_LIFECYCLE_HELP_SNIPPET_VERSION`), with relative links built through existing `relHref` / `docsLifecycleHelpHref` so `docs/adr/` and `docs/rfc/` both resolve correctly.
- **ADR template:** The full milestone table for authors remains available via `data-docs-lifecycle="adr-template"` (same content as before, moved into JS).
- **Responsive layout:** `docs/assets/docs.css` adds narrow-viewport tuning (safe-area padding on `.container`, slightly smaller headings, media `max-width`, back-to-top vs safe areas, coarse-pointer / touch affordances including 16px search input to reduce iOS zoom-on-focus).
- **Hub tables:** Index pages (ADR README, howto, runbooks, audit, RFC, internal developers, etc.) drop the redundant **Open** column and link the document title in the first column instead.
- **ADR 0018:** Wording updated to reference `renderLifecycleStatusBlocks` and to mention RFC `data-rfc-weight` with a link to the RFC index.

**Behavior affected:** Static docs site only. Pages that rely on `docs-nav.js` show the same lifecycle help as before when JS runs; without JS, injected `<details>` stay empty (same class of limitation as other injected UI).

## Change type

- [ ] `delivery` (feature/API/code behavior change)
- [x] `docs-only` (documentation structure/content/navigation only)
- [ ] `mixed` (both code and docs)

## Golden path checklist

### For `docs-only`

- [x] Document type and structure validated against `docs/internal/documentation-style-guide.html`.
- [x] Related hubs/indexes/cross-links updated where needed.
- [x] Internal docs layout/sidebar consistency verified (when `docs/internal/` changed).
- [ ] Docs normalization passed: `make docs-fix`.
- [ ] Docs drift/validation passed: `make docs-check`.

## Audit and conformance

- [x] I validated terminology consistency and naming conventions across affected pages.
- [x] I checked links/navigation for changed or new docs pages.
- [x] I reviewed this PR against `docs/internal/documentation-style-guide.html`.
- [x] If policy/process changed, I updated related ADR/RFC/docs references in this PR. *(ADR 0018 narrative only; no new ADR.)*

## Testing notes

- Commands run:
  - `make docs-check` *(required before merge; run locally on the branch)*
  - `make docs-fix` *(if the pipeline reformats anything)*
- Key output or evidence:
  - Spot-check in browser: any `docs/adr/*.html`, `docs/rfc/*.html`, `docs/adr/0000-template.html` — expand lifecycle `<details>`; confirm links to ADR 0018 and ADR 0000.
  - Narrow viewport / device toolbar: content does not overflow; search and nav remain tappable; back-to-top clears the bottom safe area on notched devices.

## Changelog

- [ ] Updated `CHANGELOG.md` (user-facing changes).
- [x] Updated `docs/CHANGELOG.md` (documentation-facing changes).
- [ ] No changelog update needed (`[skip changelog]` rationale is explicit).

**Rationale:** Documentation-only UX and maintenance; no user-facing API or product behavior. If you prefer a visible paper trail for doc readers, add a short bullet under `[Unreleased]` in `docs/CHANGELOG.md` and uncheck this box.
