### PR TITLE
ci(pages): deploy services/portal/ via GitHub Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,40 @@
+# Deploys the static developer portal (services/portal/) to GitHub Pages
+# via the Actions pipeline. Pages source in repo settings must be set to
+# "GitHub Actions" — the legacy "branch /docs" source will fail because no
+# docs/ directory exists.
+name: Deploy portal to Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "services/portal/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: services/portal
+
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Restore `make verify`, `make pre-commit-check`, and `make release-check` to green after the portal migrated to the UI Kit v2 runtime. The doc-pipeline scripts were written for the legacy `docs.css` / `docs-nav.js` shape and silently mangled v2 pages on every `docs-fix` run; this PR teaches the scripts the new shape and repairs the pages that drifted under the broken scripts.
- Migrate the public developer portal onto UI Kit v2, retire the now-unused `services/portal/internal/reference/front/` tree, and regenerate the pdoc code-reference snapshot + `docs-portal-data` / search index against the new tree.
- Patch three CVEs in pinned dependencies (`idna`, `urllib3`, `starlette`) and one in `pip` itself, pivot `deps-audit` to local-mode `pip-audit -l` (was hanging on `ensurepip` bootstrap inside a temp venv on Python 3.14), and ship a GitHub Actions Pages workflow that deploys `services/portal/` on every push to `main`.
- Restore HTML hygiene across the portal: 924 malformed `<a docs-history__author>` tags fixed across 473 pages, 32 pages with stripped `<style>` overlays restored from HEAD, 70+ anchors to deleted pages unwrapped, ~20 heading-hierarchy jumps (h1→h3, h2→h4) corrected.

## Change type

- [ ] `delivery` (feature/API/code behavior change)
- [ ] `docs-only` (documentation structure/content/navigation only)
- [x] `mixed` (both code and docs)

## Golden path checklist

### For `delivery`

- [x] Requirements/contract implications reviewed (OpenAPI, schemas, errors, versioning). — no API contract change; OpenAPI baseline + snapshot contract test unchanged.
- [x] Implementation is complete across required layers.
- [x] OpenAPI/internal docs updated in the same PR when behavior changed. — N/A (no behavior change).
- [x] Local gate passed: `make verify`. — green in ~20s.
- [x] Pre-push gate passed: `make verify`. — green, plus `make pre-commit-check` and `make release-check`.

### For `docs-only`

- [x] Document type and structure validated against `services/portal/internal/front/documentation-style-guide.html`. — `docs-design-check` passes.
- [x] Related hubs/indexes/cross-links updated where needed. — broken anchors unwrapped; `check_asset_refs` clean across 8500+ refs.
- [x] Internal docs layout/sidebar consistency verified (when `services/portal/internal/` changed). — sidebar nav-tree regenerated by the new `render_service_descriptors.py` step inside `docs-fix`.
- [x] Docs normalization passed: `make docs-fix`. — pipeline now idempotent end-to-end.
- [x] Docs drift/validation passed: `make docs-check`.

## Audit and conformance

- [x] I validated terminology consistency and naming conventions across affected pages.
- [x] I checked links/navigation for changed or new docs pages.
- [x] I reviewed this PR against `services/portal/internal/front/documentation-style-guide.html`.
- [x] If policy/process changed, I updated related ADR/RFC/docs references in this PR. — no policy/process change; only scripts and HTML repair plus the v2 migration of the public portal.

## Testing notes

- Commands run:
  - `make verify` — all 8 stages green (~20 s end-to-end).
  - `make pre-commit-check` — all 21 hooks pass.
  - `make release-check` — env-check + verify pass.
  - `make docs-fix && make docs-fix` — second run is a true no-op (idempotency confirmed).
  - `pytest -q --cov=app` — 60 passed, 91.07 % coverage (≥ 90 floor).
  - `pip-audit -l` — no known vulnerabilities.
- Key output or evidence:
  - `repair_docs_html.py` second-run drift: 612 → 0 files.
  - `format_docs_html.py` second-run drift: 612 → 0 files.
  - `check_asset_refs`: 8515 references checked, all resolve.
  - `check_css_vars`: 562 tokens declared, 6044 references, all resolved.
  - `validate_docs_a11y`: heading jumps cleared on 20 pages.
  - `validate_docs_html`: 924 malformed `<a>` tags repaired across 473 files.
  - 32 pages with stripped `<style>` overlays restored from `git HEAD`.
  - Retired scripts (unwired): `audit_add_justification_column.py`, `audit_front_docs_links.py`, `capture_screen_specs.py`, `generate_token_gallery.py`, `minify_portal_css.py`.
  - Dependency bumps (CVE-driven): `idna 3.11 → 3.15` (CVE-2026-45409), `urllib3 2.6.3 → 2.7.0` (PYSEC-2026-141, PYSEC-2026-142), `starlette 1.0.0 → 1.0.1` (PYSEC-2026-161), `pip 26.0.1 → 26.1.1` (CVE-2026-3219, CVE-2026-6357 in `.venv`).

## Changelog

- [x] Updated `CHANGELOG.md` (user-facing changes).
- [ ] Updated `services/portal/CHANGELOG.md` (documentation-facing changes). — covered by the same `CHANGELOG.md` entry; the docs changes here are pipeline repair, not new documentation content.
- [ ] No changelog update needed (`[skip changelog]` rationale is explicit).
