### PR TITLE
ci(pages): mirror services/ as Pages artifact root so portal CSS resolves

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,16 +38,35 @@ jobs:
 
       - uses: actions/configure-pages@v5
 
-      # Stage the artifact. The portal HTML references CSS/JS via
-      # `../frontend/portal/assets[_v2]/…`, which sit OUTSIDE services/portal/.
-      # Copy services/portal/ to the artifact root, then bring in the sibling
-      # services/frontend/portal/ tree so those relative paths resolve at /.
+      # Stage the artifact. Portal HTML references CSS/JS via relative paths
+      # like `../frontend/portal/assets_v2/…` (up to 7 levels deep for pdoc
+      # output). Those paths assume the *parent* of services/portal/ is the
+      # webroot, so deploying services/portal/ alone — even with frontend/
+      # bundled inside — won't work on a project Pages URL like
+      # /etr_study_api/, because `../` from /etr_study_api/index.html would
+      # escape the project scope.
+      #
+      # Instead, mirror services/ as the artifact root: portal/ stays a
+      # subdirectory, frontend/ sits next to it, and a tiny index.html at the
+      # root redirects to portal/. All `../[../…]frontend/portal/…` chains
+      # then resolve to <pages-root>/frontend/portal/… and stay inside scope.
       - name: Stage Pages artifact
         run: |
           set -euo pipefail
-          mkdir -p _site/frontend
-          cp -a services/portal/. _site/
-          cp -a services/frontend/portal _site/frontend/portal
+          mkdir -p _site
+          cp -a services/portal _site/portal
+          cp -a services/frontend _site/frontend
+          cat > _site/index.html <<'HTML'
+          <!doctype html>
+          <html lang="en"><head>
+            <meta charset="utf-8">
+            <title>Redirecting…</title>
+            <meta http-equiv="refresh" content="0; url=portal/">
+            <link rel="canonical" href="portal/">
+          </head><body>
+            <p><a href="portal/">Continue to the documentation portal</a></p>
+          </body></html>
+          HTML
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary

- Fix the Pages deploy so the portal renders styled. After PR #44 switched Pages to GitHub Actions, the deployed site served unstyled HTML — every `../frontend/portal/assets_v2/…` reference 404'd because project Pages (`/etr_study_api/`) interprets `../` as escaping above the project prefix.
- Restructure the Pages artifact to mirror `services/` instead of uploading `services/portal/` alone. The portal now lives at `_site/portal/`, the asset tree at `_site/frontend/`, and a one-line `_site/index.html` meta-refreshes the project root to `portal/`. Every `../[../…]frontend/portal/…` chain (up to 7 levels deep in pdoc output) collapses to `<pages-root>/frontend/portal/…` and stays inside scope.
- Follow-up: normalize the UI Kit relative paths. 104 UI Kit HTML pages were using `../[../…]services/frontend/portal/…` for sidebar JSON, runtime JS, and a few assets. Locally that resolves because the pages live inside `services/`; on project Pages the leading `../` chain escaped the project prefix before re-entering `services/`, so the sidebar JSON 404'd at `iboiarkin96.github.io/services/frontend/portal/…` and the sidebar never rendered. Strip the redundant `services/` segment so UI Kit paths match the rest of the portal.
- No application or content changes; only the Pages deploy workflow, a tiny synthesized landing redirect, and a 1:1 path rewrite across UI Kit HTML.

## Change type

- [x] `delivery` (feature/API/code behavior change)
- [ ] `docs-only` (documentation structure/content/navigation only)
- [ ] `mixed` (both code and docs)

## Golden path checklist

### For `delivery`

- [x] Requirements/contract implications reviewed (OpenAPI, schemas, errors, versioning). — N/A; CI/CD-only change, no API surface touched.
- [x] Implementation is complete across required layers. — workflow update + URL normalization in UI Kit HTML.
- [x] OpenAPI/internal docs updated in the same PR when behavior changed. — N/A.
- [x] Local gate passed: `make verify`. — green; HTML edits are pure path swaps.
- [x] Pre-push gate passed: `make verify`. — green; `check_asset_refs` re-validated all 8500+ references.

## Audit and conformance

- [x] I validated terminology consistency and naming conventions across affected pages. — N/A (no copy changes).
- [x] I checked links/navigation for changed or new docs pages. — `check_broken_refs` pre-commit hook ran on the staged HTML and passed.
- [x] I reviewed this PR against `services/portal/internal/foundations/reference/sa/style-guide.html`. — N/A (workflow YAML + path rewrites, not a portal page).
- [x] If policy/process changed, I updated related ADR/RFC/docs references in this PR. — no policy/process change.

## Testing notes

- Commands run:
  - `make verify` — green.
  - Verified relative-path resolution by hand: deepest pdoc page (`services/portal/internal/services/api/code-reference/app/schemas/telemetry.html`) uses 7 `../` and lands at the project Pages root.
- Key output or evidence:
  - Before this PR, `iboiarkin96.github.io/etr_study_api/` rendered without CSS and DevTools showed 404s on `iboiarkin96.github.io/frontend/portal/assets_v2/runtime/internal/entry.css` (outside the project Pages scope). Additionally `ui-kit/index.html` 404'd on the sidebar JSON at `iboiarkin96.github.io/services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json`.
  - After this PR, the artifact tree is `_site/{index.html, portal/, frontend/}`. The portal index is at `/etr_study_api/portal/index.html`, asset path is `/etr_study_api/frontend/portal/assets_v2/runtime/internal/entry.css`, sidebar JSON at `/etr_study_api/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json`.
  - HTML path rewrite: 104 files, 322 lines swapped 1:1 (`grep -c '../services/frontend/portal/'` → 0 across `services/portal/`).
  - Entry URL: `https://iboiarkin96.github.io/etr_study_api/portal/` (root redirects there).

## Changelog

- [ ] Updated `CHANGELOG.md` (user-facing changes).
- [ ] Updated `services/portal/CHANGELOG.md` (documentation-facing changes).
- [x] No changelog update needed (`[skip changelog]` rationale is explicit). — CI/CD-only fix; no behavior or docs change for users.
