### PR TITLE
fix(portal): normalize UI Kit relative paths so sidebar/JS load on Pages

### DIFF
--- a/services/portal/ui-kit/index.html
+++ b/services/portal/ui-kit/index.html
@@ -30,7 +30,7 @@
     </div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
 
@@ -197,12 +197,12 @@
 
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
   <!-- WebGL hero: lazy-load only on ≥1025 -->
   <script type="module">
     if (window.innerWidth >= 1025) {
-    import("../../../services/frontend/portal/assets_v2/ui-kit/components/home-webgl-v2.js")
+    import("../../frontend/portal/assets_v2/ui-kit/components/home-webgl-v2.js")
     .then(({ initHomeWebGL }) => {
     const canvas = document.querySelector(".lp-hero__canvas");
     initHomeWebGL(canvas);

--- a/services/portal/ui-kit/pages/components/anatomy-grid.html
+++ b/services/portal/ui-kit/pages/components/anatomy-grid.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -101,7 +101,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/author-chip.html
+++ b/services/portal/ui-kit/pages/components/author-chip.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">

--- a/services/portal/ui-kit/pages/components/breadcrumbs.html
+++ b/services/portal/ui-kit/pages/components/breadcrumbs.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -27,7 +27,7 @@
     </div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -137,7 +137,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/bug-report.html
+++ b/services/portal/ui-kit/pages/components/bug-report.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -27,7 +27,7 @@
     </div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -328,7 +328,7 @@ const FEEDBACK_TYPES = [
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/button.html
+++ b/services/portal/ui-kit/pages/components/button.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -121,7 +121,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/card.html
+++ b/services/portal/ui-kit/pages/components/card.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -185,7 +185,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/chip.html
+++ b/services/portal/ui-kit/pages/components/chip.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -147,7 +147,7 @@ aria-pressed="false"&gt;QA&lt;/button&gt;
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/close-btn.html
+++ b/services/portal/ui-kit/pages/components/close-btn.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -144,7 +144,7 @@ aria-label="Dismiss"&gt;×&lt;/button&gt;
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/cockpit.html
+++ b/services/portal/ui-kit/pages/components/cockpit.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -115,7 +115,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/code.html
+++ b/services/portal/ui-kit/pages/components/code.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -121,7 +121,7 @@ API --&gt; User: 201 Created
 
     </main>
 
-    <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+    <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
     <aside class="docs-toc" aria-label="On this page"></aside>
 
   </body></html>

--- a/services/portal/ui-kit/pages/components/compare-grid.html
+++ b/services/portal/ui-kit/pages/components/compare-grid.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -98,7 +98,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/concept-layers.html
+++ b/services/portal/ui-kit/pages/components/concept-layers.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -157,6 +157,6 @@
 
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/cta-banner.html
+++ b/services/portal/ui-kit/pages/components/cta-banner.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -95,7 +95,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/deepdive-callout.html
+++ b/services/portal/ui-kit/pages/components/deepdive-callout.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -94,7 +94,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/dep-lanes.html
+++ b/services/portal/ui-kit/pages/components/dep-lanes.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -281,6 +281,6 @@ Full graph in &lt;a href="dependencies.html"&gt;dependencies&lt;/a&gt;.
   </aside>
   <button data-component="toc-fab" type="button" aria-label="On this page" aria-expanded="false"></button>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/design-canvas-card.html
+++ b/services/portal/ui-kit/pages/components/design-canvas-card.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -156,7 +156,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/diagram-lightbox.html
+++ b/services/portal/ui-kit/pages/components/diagram-lightbox.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -123,7 +123,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/drawer.html
+++ b/services/portal/ui-kit/pages/components/drawer.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -119,7 +119,7 @@ aria-modal="true" role="dialog" hidden&gt;
 
     </main>
 
-    <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+    <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
     <aside class="docs-toc" aria-label="On this page"></aside>
 
   </body></html>

--- a/services/portal/ui-kit/pages/components/endpoint-card.html
+++ b/services/portal/ui-kit/pages/components/endpoint-card.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
 
   <main class="container">
 
@@ -188,6 +188,6 @@ stroke-linecap="round" stroke-linejoin="round"/&gt;
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/entity-card.html
+++ b/services/portal/ui-kit/pages/components/entity-card.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-h1-deep="1" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -268,7 +268,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/escalation.html
+++ b/services/portal/ui-kit/pages/components/escalation.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -186,6 +186,6 @@
 
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/example-frame.html
+++ b/services/portal/ui-kit/pages/components/example-frame.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -144,7 +144,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/feature-cards.html
+++ b/services/portal/ui-kit/pages/components/feature-cards.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -156,7 +156,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/field-row.html
+++ b/services/portal/ui-kit/pages/components/field-row.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
 
   <main class="container">
 
@@ -175,6 +175,6 @@ title="Optional" aria-label="Optional"&gt;○&lt;/span&gt;&lt;/td&gt;
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/filter-chips.html
+++ b/services/portal/ui-kit/pages/components/filter-chips.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -111,7 +111,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/footer-history.html
+++ b/services/portal/ui-kit/pages/components/footer-history.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -121,7 +121,7 @@ data-variant="sm"&gt;@iboiarkin96&lt;/a&gt;
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/glossary-list.html
+++ b/services/portal/ui-kit/pages/components/glossary-list.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -157,7 +157,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/hero.html
+++ b/services/portal/ui-kit/pages/components/hero.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-h1-deep="1" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -133,7 +133,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/home-webgl.html
+++ b/services/portal/ui-kit/pages/components/home-webgl.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -113,7 +113,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/index.html
+++ b/services/portal/ui-kit/pages/components/index.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -26,7 +26,7 @@
     </div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -267,7 +267,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/industry-cards.html
+++ b/services/portal/ui-kit/pages/components/industry-cards.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -102,7 +102,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/info-button.html
+++ b/services/portal/ui-kit/pages/components/info-button.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -261,6 +261,6 @@ stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"&gt;
     </div>
   </section>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/inline-diagram.html
+++ b/services/portal/ui-kit/pages/components/inline-diagram.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -120,7 +120,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/interactive-checklist.html
+++ b/services/portal/ui-kit/pages/components/interactive-checklist.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -180,7 +180,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/kind-block.html
+++ b/services/portal/ui-kit/pages/components/kind-block.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -26,7 +26,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -183,7 +183,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/lifecycle-box.html
+++ b/services/portal/ui-kit/pages/components/lifecycle-box.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -112,7 +112,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/method-badge.html
+++ b/services/portal/ui-kit/pages/components/method-badge.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
 
   <main class="container">
 
@@ -161,6 +161,6 @@
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/modal.html
+++ b/services/portal/ui-kit/pages/components/modal.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -125,7 +125,7 @@ aria-label="Close" data-tooltip="Close (Esc)"&gt;×&lt;/button&gt;
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/multi-filter-chips.html
+++ b/services/portal/ui-kit/pages/components/multi-filter-chips.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -116,7 +116,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/numbered-section.html
+++ b/services/portal/ui-kit/pages/components/numbered-section.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -100,7 +100,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/numbered-step-list.html
+++ b/services/portal/ui-kit/pages/components/numbered-step-list.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -101,7 +101,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/page-hero.html
+++ b/services/portal/ui-kit/pages/components/page-hero.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -101,7 +101,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/person-card.html
+++ b/services/portal/ui-kit/pages/components/person-card.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -323,7 +323,7 @@ data-target="#people-grid"&gt;
 
         </main>
 
-        <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+        <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
         <aside class="docs-toc" aria-label="On this page"></aside>
 
       </body></html>

--- a/services/portal/ui-kit/pages/components/pill.html
+++ b/services/portal/ui-kit/pages/components/pill.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -106,7 +106,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/practice-article.html
+++ b/services/portal/ui-kit/pages/components/practice-article.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -118,7 +118,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/quality-checklist.html
+++ b/services/portal/ui-kit/pages/components/quality-checklist.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -107,7 +107,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/radar.html
+++ b/services/portal/ui-kit/pages/components/radar.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
 
   <main class="container">
 
@@ -143,6 +143,6 @@ data-axes='[
 
       <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
 
-      <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+      <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
     </body></html>

--- a/services/portal/ui-kit/pages/components/reading-progress.html
+++ b/services/portal/ui-kit/pages/components/reading-progress.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">

--- a/services/portal/ui-kit/pages/components/references-grid.html
+++ b/services/portal/ui-kit/pages/components/references-grid.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -120,7 +120,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/resume-banner.html
+++ b/services/portal/ui-kit/pages/components/resume-banner.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -227,7 +227,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/rocket.html
+++ b/services/portal/ui-kit/pages/components/rocket.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -309,7 +309,7 @@ stroke="currentColor" stroke-width="1.8"&gt;
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
   <script type="module">
     // ── Demo wiring (showcase only) ───────────────────────────────────────

--- a/services/portal/ui-kit/pages/components/role-onboarding.html
+++ b/services/portal/ui-kit/pages/components/role-onboarding.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -92,7 +92,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/roles-radar.html
+++ b/services/portal/ui-kit/pages/components/roles-radar.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -92,7 +92,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/rollout-timeline.html
+++ b/services/portal/ui-kit/pages/components/rollout-timeline.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -102,7 +102,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/scene-bg.html
+++ b/services/portal/ui-kit/pages/components/scene-bg.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell has-scene-bg" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -134,7 +134,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/search.html
+++ b/services/portal/ui-kit/pages/components/search.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -132,7 +132,7 @@ role="listbox" aria-label="Search results" hidden&gt;
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/section-card.html
+++ b/services/portal/ui-kit/pages/components/section-card.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -116,7 +116,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/services-catalog.html
+++ b/services/portal/ui-kit/pages/components/services-catalog.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -95,7 +95,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/sidebar.html
+++ b/services/portal/ui-kit/pages/components/sidebar.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -27,7 +27,7 @@
     </div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -45,7 +45,7 @@
       <h2 id="sb-ex">Example · expanded</h2>
       <p>Live sidebar mounted from <code>nav-tree-uikit.json</code>. The brand block is sticky, every top-level section carries an emoji, and the chevron in the header collapses the whole rail (try it — your choice persists across reloads).</p>
       <div class="docs-example">
-        <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation (demo)"></aside>
+        <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation (demo)"></aside>
       </div>
     </section>
 
@@ -203,7 +203,7 @@ aria-label="Collapse navigation" aria-expanded="true"&gt;
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/signal-pillars.html
+++ b/services/portal/ui-kit/pages/components/signal-pillars.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -346,6 +346,6 @@ All three pillars share the same key —
 
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/site-footer.html
+++ b/services/portal/ui-kit/pages/components/site-footer.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -186,7 +186,7 @@
             // entry.js boots.
           </script>
           <script type="module">
-            import { mountSiteFooter } from "../../../../../services/frontend/portal/assets_v2/ui-kit/components/site-footer.js";
+            import { mountSiteFooter } from "../../../../frontend/portal/assets_v2/ui-kit/components/site-footer.js";
 
             // This page uses <html data-footer="off"> to suppress the global
             // auto-mount, then explicitly mounts each demo slot below. Each demo
@@ -234,6 +234,6 @@
             });
           </script>
 
-          <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+          <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
         </body></html>

--- a/services/portal/ui-kit/pages/components/sparkline.html
+++ b/services/portal/ui-kit/pages/components/sparkline.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
 
   <main class="container">
 
@@ -131,6 +131,6 @@ data-width="100"
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/spine-grid.html
+++ b/services/portal/ui-kit/pages/components/spine-grid.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -26,7 +26,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -214,7 +214,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/state-strip.html
+++ b/services/portal/ui-kit/pages/components/state-strip.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -91,7 +91,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/status-pill.html
+++ b/services/portal/ui-kit/pages/components/status-pill.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -113,7 +113,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/status-timeline.html
+++ b/services/portal/ui-kit/pages/components/status-timeline.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -337,6 +337,6 @@ the current node (0..4) so the accent fill stops at the right dot --&gt;
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/syntax-highlight.html
+++ b/services/portal/ui-kit/pages/components/syntax-highlight.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -113,7 +113,7 @@ def greet(name: str) -&gt; str:
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/table.html
+++ b/services/portal/ui-kit/pages/components/table.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -134,7 +134,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/template-annotator.html
+++ b/services/portal/ui-kit/pages/components/template-annotator.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
 
@@ -24,7 +24,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -200,11 +200,11 @@ comp: 'docs-prose h1'
 
           </main>
 
-          <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+          <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
           <!-- Eat your own dog food: this very showcase page enables the annotator. -->
           <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
-          <script type="module" src="../../../../../services/frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
+          <script type="module" src="../../../../frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
           <aside class="docs-toc" aria-label="On this page"></aside>
 
         </body></html>

--- a/services/portal/ui-kit/pages/components/terminal-card.html
+++ b/services/portal/ui-kit/pages/components/terminal-card.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -133,7 +133,7 @@ data-try-href="/services/portal/public/reference/api/index.html"
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/test-pyramid.html
+++ b/services/portal/ui-kit/pages/components/test-pyramid.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -191,6 +191,6 @@
 
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/text-decrypt.html
+++ b/services/portal/ui-kit/pages/components/text-decrypt.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">

--- a/services/portal/ui-kit/pages/components/theme-toggle.html
+++ b/services/portal/ui-kit/pages/components/theme-toggle.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -105,7 +105,7 @@ mountThemeToggle();
 
     </main>
 
-    <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+    <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
     <aside class="docs-toc" aria-label="On this page"></aside>
 
   </body></html>

--- a/services/portal/ui-kit/pages/components/tldr-callout.html
+++ b/services/portal/ui-kit/pages/components/tldr-callout.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -84,7 +84,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/toast.html
+++ b/services/portal/ui-kit/pages/components/toast.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -122,7 +122,7 @@ const t = window.docsToast.show({ message: "Uploading…", duration: 0 });
 
     </main>
 
-    <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+    <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
     <script type="module">
       // Wire example buttons → window.docsToast.show
       function wire() {

--- a/services/portal/ui-kit/pages/components/toc-fab.html
+++ b/services/portal/ui-kit/pages/components/toc-fab.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -115,7 +115,7 @@ aria-expanded="false"&gt;
 
     </main>
 
-    <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+    <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
     <aside class="docs-toc" aria-label="On this page"></aside>
 
   </body></html>

--- a/services/portal/ui-kit/pages/components/toc.html
+++ b/services/portal/ui-kit/pages/components/toc.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -209,7 +209,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/tooltip.html
+++ b/services/portal/ui-kit/pages/components/tooltip.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -233,7 +233,7 @@ role="tooltip" data-placement="top" style="left:…px; top:…px"&gt;
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/topbar.html
+++ b/services/portal/ui-kit/pages/components/topbar.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -27,7 +27,7 @@
     </div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -135,7 +135,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/view-switcher.html
+++ b/services/portal/ui-kit/pages/components/view-switcher.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
 
   <main class="container">
 
@@ -144,6 +144,6 @@ aria-label="View"&gt;
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/components/worked-example.html
+++ b/services/portal/ui-kit/pages/components/worked-example.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -98,7 +98,7 @@ CREATE TABLE card_fields (
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/foundations/css-architecture.html
+++ b/services/portal/ui-kit/pages/foundations/css-architecture.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <article class="docs-prose">
@@ -127,6 +127,6 @@
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/foundations/glossary.html
+++ b/services/portal/ui-kit/pages/foundations/glossary.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -24,7 +24,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <article class="docs-prose">
@@ -1824,6 +1824,6 @@
 
     <aside class="docs-toc" aria-label="On this page"></aside>
 
-    <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+    <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
   </body></html>

--- a/services/portal/ui-kit/pages/foundations/hotkeys.html
+++ b/services/portal/ui-kit/pages/foundations/hotkeys.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <article class="docs-prose">
@@ -125,6 +125,6 @@
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/foundations/index.html
+++ b/services/portal/ui-kit/pages/foundations/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -35,7 +35,7 @@
     </div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -129,7 +129,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/foundations/js-modules.html
+++ b/services/portal/ui-kit/pages/foundations/js-modules.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <article class="docs-prose">
@@ -177,6 +177,6 @@ boot();
       <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
       <div data-component="rocket" aria-hidden="true"></div>
 
-      <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+      <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
     </body></html>

--- a/services/portal/ui-kit/pages/foundations/layout.html
+++ b/services/portal/ui-kit/pages/foundations/layout.html
@@ -41,7 +41,7 @@
     .layout-diagram__cell--main { grid-column: 1; }
     }
   </style>
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -58,7 +58,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -137,7 +137,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/foundations/motion.html
+++ b/services/portal/ui-kit/pages/foundations/motion.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <article class="docs-prose">
@@ -136,6 +136,6 @@ transform: none !important;
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/foundations/philosophy.html
+++ b/services/portal/ui-kit/pages/foundations/philosophy.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="explanation" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <article class="docs-prose">
@@ -127,6 +127,6 @@
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/foundations/prose.html
+++ b/services/portal/ui-kit/pages/foundations/prose.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -24,7 +24,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -136,7 +136,7 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/foundations/tokens.html
+++ b/services/portal/ui-kit/pages/foundations/tokens.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
@@ -26,7 +26,7 @@
     </div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -207,7 +207,7 @@ html[data-portal="public"] {
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/templates/directory.html
+++ b/services/portal/ui-kit/pages/templates/directory.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
 </head>
 <body data-page-type="landing-directory" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
 
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
 
@@ -168,8 +168,8 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/templates/doc-article.html
+++ b/services/portal/ui-kit/pages/templates/doc-article.html
@@ -9,7 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
   <!-- Opt-in template-anatomy overlay (one CSS + one ES module, no markup changes). -->
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
 </head>
 <body data-page-type="article" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
 
@@ -26,7 +26,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
 
   <main class="container">
     <article class="docs-prose">
@@ -101,9 +101,9 @@
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
 
   <!-- Template-anatomy overlay — auto-injects toggle pill + annotations. -->
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/templates/doc-explanation.html
+++ b/services/portal/ui-kit/pages/templates/doc-explanation.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
 </head>
 <body data-page-type="explanation" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
   <header class="topbar" role="banner">
@@ -24,7 +24,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
 
   <main class="container">
     <article class="docs-prose">
@@ -97,7 +97,7 @@ ri --&gt; int
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/templates/doc-howto.html
+++ b/services/portal/ui-kit/pages/templates/doc-howto.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
 </head>
 <body data-page-type="howto" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
   <header class="topbar" role="banner">
@@ -24,7 +24,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
 
   <main class="container">
     <article class="docs-prose">
@@ -105,7 +105,7 @@ cp services/frontend/portal/assets_v2/ui-kit/templates/landing-section.html \
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/templates/doc-reference.html
+++ b/services/portal/ui-kit/pages/templates/doc-reference.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
 
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
 
   <main class="container">
 
@@ -296,7 +296,7 @@
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/templates/doc-tutorial.html
+++ b/services/portal/ui-kit/pages/templates/doc-tutorial.html
@@ -16,7 +16,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
 </head>
 <body data-page-type="tutorial" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
   <header class="topbar" role="banner">
@@ -40,7 +40,7 @@
     </div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
 
   <main class="container">
     <article class="docs-prose">
@@ -158,7 +158,7 @@
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/templates/index.html
+++ b/services/portal/ui-kit/pages/templates/index.html
@@ -16,7 +16,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
 </head>
 <body data-page-type="reference" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
   <header class="topbar" role="banner">
@@ -35,7 +35,7 @@
     </div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <header class="page-head">
@@ -187,8 +187,8 @@
 
   </main>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/templates/landing-portal.html
+++ b/services/portal/ui-kit/pages/templates/landing-portal.html
@@ -16,7 +16,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
 </head>
 <body data-page-type="landing" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
   <header class="topbar" role="banner">
@@ -35,7 +35,7 @@
     </div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Internal portal navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Internal portal navigation"></aside>
 
   <main class="container">
     <!-- ─── Hero ─────────────────────────────────────────────────── -->
@@ -213,13 +213,13 @@
 
           <div data-component="rocket" aria-hidden="true"></div>
 
-          <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
-          <script type="module" src="../../../../../services/frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
+          <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+          <script type="module" src="../../../../frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
 
           <!-- WebGL hero: lazy-load only on ≥1025 -->
           <script type="module">
             if (window.innerWidth >= 1025) {
-            import("../../../../../services/frontend/portal/assets_v2/ui-kit/components/home-webgl-v2.js")
+            import("../../../../frontend/portal/assets_v2/ui-kit/components/home-webgl-v2.js")
             .then(({ initHomeWebGL }) => {
             const canvas = document.querySelector(".lp-hero__canvas");
             initHomeWebGL(canvas);

--- a/services/portal/ui-kit/pages/templates/landing-section.html
+++ b/services/portal/ui-kit/pages/templates/landing-section.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
 </head>
 <body data-page-type="landing-section" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
 
@@ -26,7 +26,7 @@
     </div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
 
   <main class="container">
     <section class="home-hero home-hero--section">
@@ -94,8 +94,8 @@
 
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/templates/ops-cockpit.html
+++ b/services/portal/ui-kit/pages/templates/ops-cockpit.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
 </head>
 <body data-page-type="cockpit" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
 
@@ -25,7 +25,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
 
   <main class="container">
 
@@ -348,8 +348,8 @@
 
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
   <aside class="docs-toc" aria-label="On this page"></aside>
 
 </body></html>

--- a/services/portal/ui-kit/pages/templates/ops-runbook.html
+++ b/services/portal/ui-kit/pages/templates/ops-runbook.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
 </head>
 <body data-page-type="runbook" class="docs-shell" data-maintainer-ids="16fc8b78537109162984a2fdbef6e142">
   <header class="topbar" role="banner">
@@ -24,7 +24,7 @@
     <div class="topbar__actions"><button class="docs-theme-toggle" type="button" aria-label="Toggle theme"></button></div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="Section navigation"></aside>
 
   <main class="container">
     <article class="docs-prose">
@@ -109,7 +109,7 @@
   <button data-component="toc-fab" type="button" aria-label="Open on this page" aria-expanded="false"></button>
   <div data-component="rocket" aria-hidden="true"></div>
 
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
-  <script type="module" src="../../../../../services/frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+  <script type="module" src="../../../../frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
 
 </body></html>

--- a/services/portal/ui-kit/pages/templates/profile.html
+++ b/services/portal/ui-kit/pages/templates/profile.html
@@ -16,7 +16,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../../frontend/portal/assets_v2/runtime/internal/entry.css">
-  <link rel="icon" type="image/svg+xml" href="../../../../../services/frontend/portal/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="../../../../frontend/portal/assets/favicon.svg">
 </head>
 <body data-page-type="profile" class="docs-shell" data-maintainer-ids="mock-person-0000000000000000">
   <header class="topbar" role="banner">
@@ -38,7 +38,7 @@
     </div>
   </header>
 
-  <aside data-component="sidebar" data-nav-src="../../../../../services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
+  <aside data-component="sidebar" data-nav-src="../../../../frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json" aria-label="UI Kit navigation"></aside>
 
   <main class="container">
     <!-- ── Hero ────────────────────────────────────────────────────────── -->
@@ -147,8 +147,8 @@
 
       </main>
 
-      <script type="module" src="../../../../../services/frontend/portal/assets_v2/runtime/internal/entry.js"></script>
-      <script type="module" src="../../../../../services/frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
+      <script type="module" src="../../../../frontend/portal/assets_v2/runtime/internal/entry.js"></script>
+      <script type="module" src="../../../../frontend/portal/assets_v2/ui-kit/components/template-annotator.js"></script>
       <aside class="docs-toc" aria-label="On this page"></aside>
 
     </body></html>


### PR DESCRIPTION
## Summary

- 104 UI Kit HTML pages used `../[../…]services/frontend/portal/…` for sidebar JSON, runtime JS, and a handful of assets. Locally that resolves because the pages live inside `services/`; on project Pages (`/etr_study_api/…`) the leading `../` chain escaped the project prefix before re-entering `services/`, so requests went to `iboiarkin96.github.io/services/frontend/portal/…` and 404'd. The sidebar component never rendered.
- Strip the redundant `services/` segment so UI Kit paths match the rest of the portal (`../[../…]frontend/portal/…`). Once the new Pages staging step lands (PR #45), these paths collapse to `/etr_study_api/frontend/portal/…` inside scope.
- Pure 1:1 path rewrite — 322 line additions, 322 line deletions, no other edits.

## Change type

- [x] `delivery` (feature/API/code behavior change)
- [ ] `docs-only` (documentation structure/content/navigation only)
- [ ] `mixed` (both code and docs)

## Golden path checklist

### For `delivery`

- [x] Requirements/contract implications reviewed (OpenAPI, schemas, errors, versioning). — N/A; static-portal URL normalization, no API surface.
- [x] Implementation is complete across required layers. — single sweep across all UI Kit HTML.
- [x] OpenAPI/internal docs updated in the same PR when behavior changed. — N/A.
- [x] Local gate passed: `make verify`. — green; `check_asset_refs` re-validated all references.
- [x] Pre-push gate passed: `make verify`. — green.

## Audit and conformance

- [x] I validated terminology consistency and naming conventions across affected pages. — N/A (no copy changes).
- [x] I checked links/navigation for changed or new docs pages. — `check_broken_refs` pre-commit hook passed on the staged HTML.
- [x] I reviewed this PR against `services/portal/internal/foundations/reference/sa/style-guide.html`. — N/A (UI Kit asset paths, not docs content).
- [x] If policy/process changed, I updated related ADR/RFC/docs references in this PR. — no policy/process change.

## Testing notes

- Commands run:
  - `make verify` — green.
  - `grep -rn '\.\./services/frontend/portal/' services/portal --include='*.html'` — 0 remaining occurrences after the sweep.
- Key output or evidence:
  - Before: `ui-kit/index.html` and 103 other pages 404'd on `iboiarkin96.github.io/services/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json` because the leading `../` chain escaped `/etr_study_api/`.
  - After: paths resolve to `/etr_study_api/frontend/portal/assets_v2/ui-kit/mocks/nav-tree-uikit.json` — inside the project Pages scope (paired with the staging change in PR #45).
  - 104 files touched, 322 lines swapped 1:1.

## Changelog

- [ ] Updated `CHANGELOG.md` (user-facing changes).
- [ ] Updated `services/portal/CHANGELOG.md` (documentation-facing changes).
- [x] No changelog update needed (`[skip changelog]` rationale is explicit). — internal path normalization; no user-visible behavior change beyond the Pages rendering fix.
