### PR TITLE
refactor(workflows): clean up comments in CI and deployment YAML files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@
 #
 # Companion jobs (docs-a11y, pr-template-check) live here too: keep all PR/push CI in one
 # workflow. CD lives in `deploy-prod.yml` (prod Pages deploy on main),
-# `deploy-staging.yml` (mirror Pages deploy on staging — ADR-0034, BL-066), and the
+# `deploy-staging.yml` (mirror Pages deploy on staging), and the
 # `publish-image` job below (GHCR image push, gated on `quality` + `changelog` success).
 name: CI
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -8,7 +8,7 @@
 # is green; `workflow_dispatch` is kept for manual republishes.
 #
 # Pre-release counterpart: .github/workflows/deploy-staging.yml mirrors this
-# build and pushes to iboiarkin96/etr_study_api-staging (ADR-0034, BL-066).
+# build and pushes to iboiarkin96/etr_study_api-staging.
 name: Deploy Portal to Pages (prod)
 
 on:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -10,8 +10,7 @@
 #
 # Cross-repo auth: fine-grained PAT (contents:write scoped to
 # etr_study_api-staging only) stored as the STAGING_DEPLOY_TOKEN secret on
-# this repo. PAT chosen over GitHub App per BL-066 W0 fallback path —
-# single secret, no .pem juggling, equivalent scope.
+# this repo.
 #
 # Trigger model mirrors deploy-prod.yml: workflow_run on CI success for the
 # `staging` branch. ci.yml must include `staging` in its push.branches list.

--- a/services/portal/internal/governance/backlog/data/tasks.json
+++ b/services/portal/internal/governance/backlog/data/tasks.json
@@ -1870,7 +1870,7 @@
         "feature"
       ],
       "sprint": "2026-W23",
-      "status": "in-progress",
+      "status": "done",
       "priority": "P1",
       "eta_hours": 6,
       "owner": "ivan",

--- a/tools/governance/check_pr_body.sh
+++ b/tools/governance/check_pr_body.sh
@@ -5,7 +5,7 @@ repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
 branch="$(git rev-parse --abbrev-ref HEAD)"
-# main/master/staging are long-lived deploy-tracked branches (ADR-0034, BL-066);
+# main/master/staging are long-lived deploy-tracked branches
 # they don't carry a PR body. Detached HEAD too (CI checkout, rebase, bisect).
 if [[ "$branch" == "HEAD" || "$branch" == "main" || "$branch" == "master" || "$branch" == "staging" ]]; then
   exit 0


### PR DESCRIPTION
## Summary

End-to-end test of the BL-066 W1 staging-deploy flow on a real feature branch.

- Pure comment/data cleanup on top of the W1 pipelines: trim the BL/ADR cross-references in workflow comments, mark a completed task `done` in `tasks.json`, simplify the `check_pr_body.sh` preamble.
- No behavioural change to CI or the deploy pipelines — comments only.
- The purpose of this PR is to walk the `feature/* → staging → main` path for the first time and verify the stage URL updates without prod being touched.

## Change type

- [ ] `delivery` (feature/API/code behavior change)
- [ ] `docs-only` (documentation structure/content/navigation only)
- [x] `mixed` (both code and docs)

## Golden path checklist

### For `delivery`

- [x] No requirement/contract implications — workflow comments + one data status flip only.
- [x] Implementation is complete across required layers (single PR scope).
- [x] No behaviour changed → no OpenAPI/internal docs update needed.
- [x] Local gate passed: `make verify` / `make docs-check`.
- [x] Pre-push gate passed: same.

### For `docs-only`

- [x] Document type unaffected — only comment text in YAML.
- [x] No hub/index/cross-link changes needed.
- [x] No internal docs layout/sidebar consistency impact.
- [x] Docs normalisation passed: `make docs-fix` (no drift).
- [x] Docs drift/validation passed: `make docs-check`.

## Audit and conformance

- [x] Terminology consistency unaffected — text removed, not added.
- [x] Links/navigation unaffected.
- [x] Reviewed against `services/portal/internal/handbook/sa/style-guide.html`.
- [x] No policy/process change → no ADR/RFC updates needed.

## Testing notes

- Commands run:
  - `git push origin test/ci_staging`
  - `gh pr create --base staging --head test/ci_staging`
- Key output or evidence:
  - On merge, `deploy-staging.yml` should fire and update https://iboiarkin96.github.io/etr_study_api-staging/ within ~60 s.
  - Prod URL https://iboiarkin96.github.io/etr_study_api/ remains untouched until a separate `staging → main` PR.

## Changelog

- [x] No changelog update needed (comment + status cleanup only, `[skip changelog]`).